### PR TITLE
Feat/39/버튼컴포넌트

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -9,6 +9,14 @@ const preview: Preview = {
         date: /Date$/i,
       },
     },
+    backgrounds: {
+      default: 'light',
+      values: [
+        { name: 'light', value: '#ffffff' },
+        { name: 'dark', value: '#333333' },
+        { name: 'custom', value: '#404040' },
+      ],
+    },
   },
 };
 

--- a/src/components/Button.stories.ts
+++ b/src/components/Button.stories.ts
@@ -8,8 +8,7 @@ const meta: Meta<typeof Button> = {
   parameters: {
     docs: {
       description: {
-        component:
-          '이 컴포넌트는 SVGProps<SVGSVGElement>를 확장하여 모든 SVG 속성을 지원합니다. \n className에 tailwindcss를 활용하여, 반응형처리를 할 수 있습니다.',
+        component: 'Button 컴포넌트',
       },
     },
   },

--- a/src/components/Button.stories.ts
+++ b/src/components/Button.stories.ts
@@ -1,0 +1,67 @@
+import { Meta, StoryObj } from '@storybook/react';
+import Button from './Button';
+
+const meta: Meta<typeof Button> = {
+  component: Button,
+  title: 'Components/Button',
+  tags: ['autodocs'],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          '이 컴포넌트는 SVGProps<SVGSVGElement>를 확장하여 모든 SVG 속성을 지원합니다. \n className에 tailwindcss를 활용하여, 반응형처리를 할 수 있습니다.',
+      },
+    },
+  },
+  argTypes: {
+    variant: { control: 'select', description: '스타일 variant', options: ['default', 'outlined'] },
+    size: {
+      control: 'select',
+      description:
+        '버튼 size, default = 입력폼 | xs = 댓글 저장 버튼 | md = 랜딩 페이지 버튼 | lg = 사용처 없음',
+      options: ['default', 'xs', 'md', 'lg'],
+    },
+    className: { control: 'text', description: 'className' },
+    children: { control: 'text', description: '버튼 텍스트' },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Button>;
+
+export const Default: Story = {
+  args: {
+    variant: 'default',
+    size: 'default',
+    children: '가입하기',
+    className: 'w-[640px]',
+  },
+  parameters: {
+    layout: 'centered',
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    disabled: true,
+    variant: 'default',
+    size: 'default',
+    children: '가입하기',
+    className: 'w-[640px]',
+  },
+  parameters: {
+    layout: 'centered',
+  },
+};
+
+export const Outlined: Story = {
+  args: {
+    variant: 'outlined',
+    size: 'default',
+    children: '가입하기',
+  },
+  parameters: {
+    layout: 'centered',
+    backgrounds: { default: 'custom' },
+  },
+};

--- a/src/components/Button.test.tsx
+++ b/src/components/Button.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen } from '@testing-library/react';
+import Button from './Button';
+
+describe('Button 컴포넌트', () => {
+  it('기본 variant와 size로 렌더링된다', () => {
+    render(<Button>클릭하기</Button>);
+    const buttonElement = screen.getByRole('button', { name: /클릭하기/i });
+    expect(buttonElement).toHaveClass('bg-black-500');
+    expect(buttonElement).toHaveClass('h-[44px]');
+  });
+
+  it('outlined variant로 렌더링된다', () => {
+    render(<Button variant='outlined'>클릭하기</Button>);
+    const buttonElement = screen.getByRole('button', { name: /클릭하기/i });
+    expect(buttonElement).toHaveClass('bg-transparent');
+    expect(buttonElement).toHaveClass('border');
+  });
+
+  it('size prop이 xs로 전달되면 xs 사이즈 클래스가 적용된다', () => {
+    render(<Button size='xs'>클릭하기</Button>);
+    const buttonElement = screen.getByRole('button', { name: /클릭하기/i });
+    expect(buttonElement).toHaveClass('h-[32px]');
+  });
+
+  it('추가 className prop이 적용된다', () => {
+    render(<Button className='custom-class'>클릭하기</Button>);
+    const buttonElement = screen.getByRole('button', { name: /클릭하기/i });
+    expect(buttonElement).toHaveClass('custom-class');
+  });
+
+  it('disabled 상태일 때 disabled 속성이 적용된다', () => {
+    render(<Button disabled>클릭하기</Button>);
+    const buttonElement = screen.getByRole('button', { name: /클릭하기/i });
+    expect(buttonElement).toBeDisabled();
+  });
+});

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -1,0 +1,39 @@
+import { cva, VariantProps } from 'class-variance-authority';
+import React, { ButtonHTMLAttributes } from 'react';
+import { cn } from '@/utils/helper';
+
+const buttonVariants = cva(
+  'inline-flex items-center justify-center rounded-xl font-semibold text-blue-100 disabled:cursor-not-allowed px-4 py-2 cursor-pointer transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2',
+  {
+    variants: {
+      variant: {
+        default:
+          'bg-black-500 hover:bg-black-600 active:bg-black-700 disabled:bg-blue-400 disabled:border-blue-300',
+        outlined:
+          'border-black-500 hover:border-black-600 active:border-black-700 border bg-transparent disabled:border-blue-400 disabled:bg-blue-300',
+      },
+      size: {
+        default: 'lg:text-xl h-[44px] text-lg lg:h-[64px] w-full',
+        xs: 'h-[32px] w-[53px] text-xs lg:h-[44px] lg:w-[60px] lg:text-lg',
+        md: 'h-[48px] w-[112px] text-lg lg:h-[56px] lg:w-[136px] lg:text-xl',
+        lg: 'h-[64px] w-[286px] text-xl',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+      size: 'default',
+    },
+  },
+);
+
+interface ButtonProps
+  extends ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof buttonVariants> {}
+
+export default function Button({ className, variant, size, children, ...props }: ButtonProps) {
+  return (
+    <button className={cn(buttonVariants({ variant, size }), className)} {...props}>
+      {children}
+    </button>
+  );
+}


### PR DESCRIPTION
## ❓이슈

- close #39 

## :memo: Description

**작업 내용**
- 버튼 컴포넌트 추가
- 스토리북 배경색 설정 추가
  - 버튼 컴포넌트에 투명 배경의 버튼이 있어, 스토리북 배경색을 설정할 수 있도록 추가해놨습니다.

## :cyclone: PR Type

어떤 변경 사항이 있나요?

<!-- 해당 사항에 체크해 주세요. -->

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항 (오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [x] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

### PR

<!-- 작성중인 PR인 경우, Draft 모드로 생성해주세요. -->

- [x] Branch Convention 확인
  > `feat/*` 기능 구현, `fix/*` 버그 수정, `refactor/*` 개선
- [x] Base Branch 확인
- [x] 적절한 Label 지정
- [x] Assignee 및 Reviewer 지정
