### PR TITLE
Fix/54/스토리북폰트교체

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -1,5 +1,6 @@
 import type { Preview } from '@storybook/react';
 import '../src/assets/css/globals.css';
+import './style.css';
 
 const preview: Preview = {
   parameters: {

--- a/.storybook/style.css
+++ b/.storybook/style.css
@@ -1,0 +1,5 @@
+@import url("https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/variable/pretendardvariable.min.css");
+
+html{
+  font-family: 'Pretendard variable', sans-serif
+}


### PR DESCRIPTION
## ❓이슈

- close #54

## :memo: Description

<!-- 어떤 내용의 PR인지 작성해 주세요. (ex. 메인 페이지 레이아웃 작업) -->
<!-- ⚠️ PR에는 해당 PR의 제목에 해당하는 내용만 들어가 있어야 합니다!  -->
스토리북의 Components Preview에서 pretendard가 제대로 랜더링되지 않아, 폰트를 cdn으로 변경했습니다.
- 로컬에서 확인하면 미리 설치되어있는 pretendard가 렌더링되어서 제대로 체크가 되지 않습니다
- 다른 컴퓨터에서 폰트가 제대로 노출되는것을 확인했습니다.

**변경전(로컬폰트를 불러옴, 로컬에 폰트가 없으면 맑은고딕 또는 애플산돌고딕으로 뜸)**
<img width="612" alt="image" src="https://github.com/user-attachments/assets/5fe43d5c-5f1e-400c-818f-bf61cce54e59" />

**변경후(네트워크리소스로 폰트를 받아옴)**
<img width="609" alt="image" src="https://github.com/user-attachments/assets/b95502bf-8abf-4f24-8529-76a0ee55d49c" />

**문제점(한계)**
preview.ts를 타는 컴포넌트 프리뷰 부분의 폰트는 이렇게 제어가 가능한데, mdx파일로 생성된 'design system'쪽은 여전히 폰트 적용이 불가능한것 같아요. 
storybook에서 자신들의 스토리북테마를 오염시키지 않기위해서 프리뷰쪽은 아이프레임으로 싸져있고, 저희가 preview를 위해 작성하는 모든 설정은 이 아이프레임 내부에서 일어나는데, mdx파일은 이 아이프레임으로 들어가지 않네요.


**pretendard github repo**
https://github.com/orioncactus/pretendard?tab=readme-ov-file#%EA%B0%80%EB%B3%80-%EA%B8%80%EA%BC%B4

```
@import url("https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/variable/pretendardvariable.min.css");

html{
  font-family: 'Pretendard variable', sans-serif
}

```
```
import type { Preview } from '@storybook/react';
import '../src/assets/css/globals.css';
import './style.css';

const preview: Preview = {
  parameters: {
    ...
  },
};

export default preview;
```

## :cyclone: PR Type

어떤 변경 사항이 있나요?

<!-- 해당 사항에 체크해 주세요. -->

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항 (오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

### PR

<!-- 작성중인 PR인 경우, Draft 모드로 생성해주세요. -->

- [x] Branch Convention 확인
  > `feat/*` 기능 구현, `fix/*` 버그 수정, `refactor/*` 개선
- [x] Base Branch 확인
- [x] 적절한 Label 지정
- [x] Assignee 및 Reviewer 지정
