### PR TITLE
Feat/95/마이페이지 캘린더

### DIFF
--- a/src/apis/emotion/emotion.type.ts
+++ b/src/apis/emotion/emotion.type.ts
@@ -3,7 +3,7 @@ import { User } from '../user/user.type';
 import { z } from 'zod';
 
 export type EmotionLog = {
-  createAt: string;
+  createdAt: string;
   emotion: Emotion;
   userId: User['id'];
   id: number;

--- a/src/app/(after-login)/mypage/_components/MyCalendar.tsx
+++ b/src/app/(after-login)/mypage/_components/MyCalendar.tsx
@@ -1,0 +1,46 @@
+'use client';
+
+import React, { useEffect, useState } from 'react';
+import { useSession } from 'next-auth/react';
+import { getEmotionLogsMonthly } from '@/apis/emotion/emotion.service';
+import { Emotion } from '@/types/common';
+import { format } from 'date-fns';
+import Calendar from '@/components/Calendar';
+
+export default function MyCalendar() {
+  const [moodData, setMoodData] = useState<{ [dateString: string]: Emotion }>({});
+  const [currentMonth, setCurrentMonth] = useState(new Date());
+
+  const { data: session } = useSession();
+  const userId = session?.user?.id;
+
+  useEffect(() => {
+    async function fetchEmotionLogs() {
+      if (!userId) return;
+
+      try {
+        const year = currentMonth.getFullYear();
+        const month = currentMonth.getMonth() + 1;
+
+        const data = await getEmotionLogsMonthly({ userId, year, month });
+
+        const formattedData: { [dateString: string]: Emotion } = {};
+        data.forEach((log) => {
+          const dateKey = format(new Date(log.createdAt), 'yyyy-MM-dd');
+          formattedData[dateKey] = log.emotion;
+        });
+
+        setMoodData(formattedData);
+      } catch (error) {
+        console.error('감정 데이터를 불러오는 중 오류 발생:', error);
+      }
+    }
+
+    fetchEmotionLogs();
+  }, [userId, currentMonth]);
+  return (
+    <div className='mt-[58px] mb-[58px] md:mt-[62px] md:mb-[62px] lg:mt-[165px] lg:mb-[165px]'>
+      <Calendar moodData={moodData} onMonthChange={setCurrentMonth} />
+    </div>
+  );
+}

--- a/src/components/Calendar.tsx
+++ b/src/components/Calendar.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import {
   format,
   startOfMonth,
@@ -20,11 +20,18 @@ import EmotionFilter from './EmotionFilter';
 
 export interface CalendarProps {
   moodData?: { [dateString: string]: Emotion };
+  onMonthChange?: (newMonth: Date) => void;
 }
 
-export default function Calendar({ moodData }: CalendarProps) {
+export default function Calendar({ moodData, onMonthChange }: CalendarProps) {
   const [currentMonth, setCurrentMonth] = useState(new Date());
   const [filterEmotion, setFilterEmotion] = useState<Emotion | null>(null);
+
+  useEffect(() => {
+    if (onMonthChange) {
+      onMonthChange(currentMonth);
+    }
+  }, [currentMonth, onMonthChange]);
 
   function renderHeader() {
     return (


### PR DESCRIPTION
## ❓이슈

- close #95 

## :memo: Description
- MyCalendar 컴포넌트 구현 : 마이페이지에서 로그인한 사용자의 감정 기록을 캘린더에 보여줌
  - useSession 훅을 사용하여 로그인한 사용자 정보를 가져오고, 해당 사용자에 대한 감정 데이터를 API에서 가져옵니다.
  - getEmotionLogsMonthly API를 호출하여 사용자의 감정 데이터를 해당 월에 맞춰 불러오고, 이를 캘린더에 표시할 수 있도록 moodData 상태에 저장합니다.
  - Calendar 컴포넌트에 moodData를 전달하고, 월 변경 시 부모 컴포넌트인 MyCalendar에서 currentMonth를 업데이트하여 해당 월의 감정 데이터를 가져올 수 있도록 구현했습니다.

## :cyclone: PR Type

어떤 변경 사항이 있나요?

<!-- 해당 사항에 체크해 주세요. -->

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항 (오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

### PR

<!-- 작성중인 PR인 경우, Draft 모드로 생성해주세요. -->

- [x] Branch Convention 확인
  > `feat/*` 기능 구현, `fix/*` 버그 수정, `refactor/*` 개선
- [x] Base Branch 확인
- [x] 적절한 Label 지정
- [x] Assignee 및 Reviewer 지정
