### PR TITLE
Bug/163/로컬스토리지key값변경

### DIFF
--- a/src/store/feedsListTypeStore.ts
+++ b/src/store/feedsListTypeStore.ts
@@ -17,6 +17,6 @@ export const useFeedsListTypeStore = create(
         });
       },
     }),
-    { name: 'feedslistType' },
+    { name: 'feeds-list-type' },
   ),
 );

--- a/src/store/recentSearchStore.ts
+++ b/src/store/recentSearchStore.ts
@@ -24,6 +24,6 @@ export const useRecentSearchStore = create(
       },
       clear: () => set({ keywords: [] }),
     }),
-    { name: 'recentKeywords' },
+    { name: 'recent-keywords' },
   ),
 );


### PR DESCRIPTION
## ❓이슈

- close #163

## :memo: Description

<!-- 어떤 내용의 PR인지 작성해 주세요. (ex. 메인 페이지 레이아웃 작업) -->
<!-- ⚠️ PR에는 해당 PR의 제목에 해당하는 내용만 들어가 있어야 합니다!  -->

### 작업내용
useLocalStorage hook을 zustand persist로 교체하는 과정중,
기존의 로컬스토리지 key과 동일한 문제로, 이미 데이터가 저장되어있으면 랜더링 오류를 겪는 문제를 해결했습니다.

### 해결방법
기존 훅에서 사용하던 로컬스토리지 키와 다른 키값으로 변경했습니다.
```ts
// 최근검색어 (기존)
   { name: 'recentKeywords' }
// 최근검색어 (변경
   { name: 'recent-keywords' }

// 리스트타입 (기존)
   { name: 'feedsListType' }
// 최근검색어 (변경
   { name: 'feeds-list-type' }
```
## :cyclone: PR Type

어떤 변경 사항이 있나요?

<!-- 해당 사항에 체크해 주세요. -->

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항 (오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

### PR

<!-- 작성중인 PR인 경우, Draft 모드로 생성해주세요. -->

- [ ] Branch Convention 확인
  > `feat/*` 기능 구현, `fix/*` 버그 수정, `refactor/*` 개선
- [ ] Base Branch 확인
- [ ] 적절한 Label 지정
- [ ] Assignee 및 Reviewer 지정
