### PR TITLE
Feat/152/마이페이지 댓글수정삭제

### DIFF
--- a/src/apis/comment/comment.queries.ts
+++ b/src/apis/comment/comment.queries.ts
@@ -1,6 +1,7 @@
-import { useInfiniteQuery } from '@tanstack/react-query';
-import { getComments } from './comment.service';
+import { useInfiniteQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { getComments, deleteComment } from './comment.service';
 import { PaginationQueryParams } from '@/types/common';
+import { Comment } from './comment.type';
 
 export const useCommentsInfiniteQuery = (params: Omit<PaginationQueryParams, 'cursor'>) => {
   return useInfiniteQuery({
@@ -9,5 +10,29 @@ export const useCommentsInfiniteQuery = (params: Omit<PaginationQueryParams, 'cu
       getComments({ ...params, cursor: pageParam }),
     initialPageParam: undefined,
     getNextPageParam: (lastPage) => lastPage.nextCursor || undefined,
+  });
+};
+
+export const useDeleteComment = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (commentId: Comment['id']) => deleteComment(commentId),
+    onSuccess: (_, commentId) => {
+      queryClient.invalidateQueries({ queryKey: ['userComments'] });
+
+      queryClient.setQueryData<{
+        pages: { list: Comment[]; nextCursor?: number }[];
+      }>(['userComments'], (oldData) => {
+        if (!oldData) return oldData;
+
+        return {
+          ...oldData,
+          pages: oldData.pages.map((page) => ({
+            ...page,
+            list: page.list.filter((comment) => comment.id !== commentId),
+          })),
+        };
+      });
+    },
   });
 };

--- a/src/app/(after-login)/mypage/_components/MyComments.tsx
+++ b/src/app/(after-login)/mypage/_components/MyComments.tsx
@@ -4,12 +4,14 @@ import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { toast } from 'react-toastify';
 import { useDeleteComment } from '@/apis/comment/comment.queries';
+import { useUpdateComment } from '@/apis/comment/comment.queries';
 import type { Comment as CommentType } from '@/apis/comment/comment.type';
 import Comment from '@/components/Comment';
 import Spinner from '@/components/Spinner';
 import EtcButton from '@/components/EtcButton';
 import Icon from '@/components/Icon';
 import DeleteModal from '@/components/DeleteModal';
+import CommentEditForm from '@/components/CommentEditForm';
 import Image from 'next/image';
 import emptyImg from '@/assets/img/empty.png';
 
@@ -27,8 +29,51 @@ export default function MyComments({
   fetchNextPage,
 }: MyCommentsProps) {
   const router = useRouter();
-  const [selectedCommentId, setSelectedCommentId] = useState<number | null>(null);
+  const { mutate: updateComment, isPending: isUpdatePending } = useUpdateComment();
   const { mutate: deleteComment, isPending: isDeletePending } = useDeleteComment();
+
+  const [editCommentId, setEditCommentId] = useState<number | null>(null);
+  const [editedContent, setEditedContent] = useState<string>('');
+  const [isPrivate, setIsPrivate] = useState<boolean>(false);
+
+  const [selectedCommentId, setSelectedCommentId] = useState<number | null>(null);
+
+  const handleEdit = (comment: CommentType) => {
+    setEditCommentId(comment.id);
+    setEditedContent(comment.content);
+    setIsPrivate(comment.isPrivate);
+  };
+
+  const handleSaveEdit = () => {
+    const trimmedContent = editedContent.trim();
+
+    if (!editCommentId || !trimmedContent) {
+      toast.error('댓글을 입력해주세요');
+      return;
+    }
+
+    if (trimmedContent.length > 100) {
+      toast.error('100자 이내로 작성해주세요');
+      return;
+    }
+
+    updateComment(
+      { commentId: editCommentId, data: { content: trimmedContent, isPrivate } },
+      {
+        onSuccess: () => {
+          toast.success('댓글이 수정되었습니다.');
+          setEditCommentId(null);
+        },
+        onError: () => {
+          toast.error('댓글 수정에 실패했습니다.');
+        },
+      },
+    );
+  };
+
+  const handleCancelEdit = () => {
+    setEditCommentId(null);
+  };
 
   const handleDeleteConfirm = (commentId: number) => {
     setSelectedCommentId(commentId);
@@ -58,7 +103,24 @@ export default function MyComments({
       <ul>
         {comments.map((comment) => (
           <li key={comment.id}>
-            <Comment {...comment} handleDelete={() => handleDeleteConfirm(comment.id)} />
+            {editCommentId === comment.id ? (
+              <CommentEditForm
+                comment={comment}
+                editedContent={editedContent}
+                setEditedContent={setEditedContent}
+                isPrivate={isPrivate}
+                setIsPrivate={setIsPrivate}
+                isUpdatePending={isUpdatePending}
+                handleSaveEdit={handleSaveEdit}
+                handleCancelEdit={handleCancelEdit}
+              />
+            ) : (
+              <Comment
+                {...comment}
+                handleEdit={() => handleEdit(comment)}
+                handleDelete={() => handleDeleteConfirm(comment.id)}
+              />
+            )}
           </li>
         ))}
       </ul>

--- a/src/app/(after-login)/mypage/_components/MyComments.tsx
+++ b/src/app/(after-login)/mypage/_components/MyComments.tsx
@@ -1,13 +1,17 @@
 'use client';
 
+import { useState } from 'react';
 import { useRouter } from 'next/navigation';
+import { toast } from 'react-toastify';
+import { useDeleteComment } from '@/apis/comment/comment.queries';
+import type { Comment as CommentType } from '@/apis/comment/comment.type';
 import Comment from '@/components/Comment';
 import Spinner from '@/components/Spinner';
 import EtcButton from '@/components/EtcButton';
 import Icon from '@/components/Icon';
+import DeleteModal from '@/components/DeleteModal';
 import Image from 'next/image';
 import emptyImg from '@/assets/img/empty.png';
-import type { Comment as CommentType } from '@/apis/comment/comment.type';
 
 interface MyCommentsProps {
   comments: CommentType[];
@@ -23,6 +27,26 @@ export default function MyComments({
   fetchNextPage,
 }: MyCommentsProps) {
   const router = useRouter();
+  const [selectedCommentId, setSelectedCommentId] = useState<number | null>(null);
+  const { mutate: deleteComment, isPending: isDeletePending } = useDeleteComment();
+
+  const handleDeleteConfirm = (commentId: number) => {
+    setSelectedCommentId(commentId);
+  };
+
+  const handleDelete = () => {
+    if (!selectedCommentId) return;
+
+    deleteComment(selectedCommentId, {
+      onSuccess: () => {
+        toast.success('댓글이 삭제되었습니다.');
+        setSelectedCommentId(null);
+      },
+      onError: () => {
+        toast.error('댓글 삭제에 실패했습니다.');
+      },
+    });
+  };
 
   const isShowLoader = isFetching;
   const isShowMoreTrigger = !isFetching && hasNextPage;
@@ -34,7 +58,7 @@ export default function MyComments({
       <ul>
         {comments.map((comment) => (
           <li key={comment.id}>
-            <Comment {...comment} />
+            <Comment {...comment} handleDelete={() => handleDeleteConfirm(comment.id)} />
           </li>
         ))}
       </ul>
@@ -84,6 +108,14 @@ export default function MyComments({
           </EtcButton>
         </div>
       )}
+
+      <DeleteModal
+        isOpen={selectedCommentId !== null}
+        type='comment'
+        onClose={() => setSelectedCommentId(null)}
+        onDelete={handleDelete}
+        isSubmitting={isDeletePending}
+      />
     </>
   );
 }

--- a/src/app/(after-login)/mypage/_components/MyComments.tsx
+++ b/src/app/(after-login)/mypage/_components/MyComments.tsx
@@ -1,26 +1,28 @@
 'use client';
 
-import { useSession } from 'next-auth/react';
 import { useRouter } from 'next/navigation';
-import { useUserCommentsByIdInFiniteQuery } from '@/apis/user/user.queries';
 import Comment from '@/components/Comment';
 import Spinner from '@/components/Spinner';
 import EtcButton from '@/components/EtcButton';
 import Icon from '@/components/Icon';
 import Image from 'next/image';
 import emptyImg from '@/assets/img/empty.png';
+import type { Comment as CommentType } from '@/apis/comment/comment.type';
 
-export default function MyComments() {
-  const { data: session } = useSession();
-  const userId = session?.user?.id;
+interface MyCommentsProps {
+  comments: CommentType[];
+  isFetching: boolean;
+  hasNextPage: boolean;
+  fetchNextPage: () => void;
+}
 
+export default function MyComments({
+  comments,
+  isFetching,
+  hasNextPage,
+  fetchNextPage,
+}: MyCommentsProps) {
   const router = useRouter();
-
-  const { data, isFetching, hasNextPage, fetchNextPage } = useUserCommentsByIdInFiniteQuery(
-    userId ? { userId, limit: 4 } : { userId: 0, limit: 4 },
-  );
-
-  const comments = data?.pages.flatMap((page) => page.list) ?? [];
 
   const isShowLoader = isFetching;
   const isShowMoreTrigger = !isFetching && hasNextPage;

--- a/src/app/(after-login)/mypage/_components/MyEpigrams.tsx
+++ b/src/app/(after-login)/mypage/_components/MyEpigrams.tsx
@@ -1,26 +1,28 @@
 'use client';
 
-import { useSession } from 'next-auth/react';
 import { useRouter } from 'next/navigation';
-import { useEpigramWriterFilterInfiniteQuery } from '@/apis/epigram/epigram.queries';
 import Card from '@/components/Card';
 import Spinner from '@/components/Spinner';
 import EtcButton from '@/components/EtcButton';
 import Icon from '@/components/Icon';
 import Image from 'next/image';
 import emptyImg from '@/assets/img/empty.png';
+import { Epigram } from '@/apis/epigram/epigram.type';
 
-export default function MyEpigrams() {
-  const { data: session } = useSession();
-  const userId = session?.user?.id;
+interface MyEpigramsProps {
+  epigrams: Epigram[];
+  isFetching: boolean;
+  hasNextPage: boolean;
+  fetchNextPage: () => void;
+}
 
+export default function MyEpigrams({
+  epigrams,
+  isFetching,
+  hasNextPage,
+  fetchNextPage,
+}: MyEpigramsProps) {
   const router = useRouter();
-
-  const { data, isFetching, hasNextPage, fetchNextPage } = useEpigramWriterFilterInfiniteQuery(
-    userId ? { writerId: userId, limit: 4 } : { writerId: 0, limit: 4 },
-  );
-
-  const epigrams = data?.pages.flatMap((page) => page.list) ?? [];
 
   const isShowLoader = isFetching;
   const isShowMoreTrigger = !isFetching && hasNextPage;

--- a/src/components/Comment.stories.ts
+++ b/src/components/Comment.stories.ts
@@ -30,7 +30,7 @@ const meta: Meta<typeof Comment> = {
       control: 'object',
     },
 
-    createdAt: {
+    updatedAt: {
       description: '작성일과 현재 시간의 차이',
       table: {
         type: { summary: 'date' },
@@ -72,7 +72,7 @@ export const Default: Story = {
     content:
       '이 세상에는 위대한 진실이 하나 있어. 무언가를 온 마음을 다해 원한다면, 반드시 그렇게 된다는 거야. 무언가를 바라는 마음은 곧 우주의 마음으로부터 비롯된 것이기 때문이지.',
     writer: { image: 'https://placehold.co/40x40/000000/FFFFFF.png', nickname: '파울로 코엘료' },
-    createdAt: '2025-03-14T12:04:09.521Z',
+    updatedAt: '2025-03-14T12:04:09.521Z',
     className: '',
     handleEdit: () => alert('수정 버튼 클릭'),
     handleDelete: () => alert('삭제 버튼 클릭'),

--- a/src/components/Comment.test.tsx
+++ b/src/components/Comment.test.tsx
@@ -11,7 +11,7 @@ describe('댓글 컴포넌트', () => {
       image: 'https://placehold.co/40x40/000000/FFFFFF.png',
       nickname: '테스터',
     },
-    createdAt: '2025-03-14T12:04:09.521Z',
+    updatedAt: '2025-03-14T12:04:09.521Z',
     className: '',
     handleEdit: mockHandleEdit,
     handleDelete: mockHandleDelete,

--- a/src/components/Comment.tsx
+++ b/src/components/Comment.tsx
@@ -10,7 +10,7 @@ interface CommentProps {
     image: string;
     nickname: string;
   };
-  createdAt: string;
+  updatedAt: string;
   className?: string;
   handleEdit?: () => void;
   handleDelete?: () => void;
@@ -19,7 +19,7 @@ interface CommentProps {
 export default function Comment({
   content,
   writer,
-  createdAt,
+  updatedAt,
   className,
   handleEdit,
   handleDelete,
@@ -44,7 +44,7 @@ export default function Comment({
       <div className={classes.commentBox}>
         <div className={classes.commentInfo}>
           <div className={classes.commentInfoText}>{writer.nickname}</div>
-          <div className={cn(classes.commentInfoText, 'ml-2')}>{formatTime(createdAt)}</div>
+          <div className={cn(classes.commentInfoText, 'ml-2')}>{formatTime(updatedAt)}</div>
           <ul className={classes.commentInfoBtns}>
             <li>
               <button

--- a/src/components/CommentEditForm.tsx
+++ b/src/components/CommentEditForm.tsx
@@ -1,0 +1,63 @@
+import { Comment } from '@/apis/comment/comment.type';
+import Avatar from './Avatar';
+import Button from './Button';
+import Toggle from './Toggle';
+
+interface CommentEditFormProps {
+  comment: Comment;
+  editedContent: string;
+  setEditedContent: React.Dispatch<React.SetStateAction<string>>;
+  isPrivate: boolean;
+  setIsPrivate: React.Dispatch<React.SetStateAction<boolean>>;
+  isUpdatePending: boolean;
+  handleSaveEdit: () => void;
+  handleCancelEdit: () => void;
+}
+
+export default function CommentEditForm({
+  comment,
+  editedContent,
+  setEditedContent,
+  isPrivate,
+  setIsPrivate,
+  isUpdatePending,
+  handleSaveEdit,
+  handleCancelEdit,
+}: CommentEditFormProps) {
+  return (
+    <div className='border-line-200 flex items-start border-t px-6 py-4 text-left md:py-6 lg:py-9'>
+      <Avatar src={comment.writer.image} alt={comment.writer.nickname} />
+      <div className='ml-4 flex flex-1 flex-col gap-2 lg:gap-4'>
+        <textarea
+          value={editedContent}
+          onChange={(e) => setEditedContent(e.target.value)}
+          className='border-black-600 text-md text-black-700 w-full resize-none rounded-lg border px-4 py-3 md:text-lg lg:text-xl'
+        />
+        <div className='flex items-center justify-between'>
+          <Toggle
+            label='공개'
+            checked={!isPrivate}
+            onChange={() => setIsPrivate((prev) => !prev)}
+          />
+          <div className='flex gap-2'>
+            <Button
+              size='xs'
+              onClick={handleSaveEdit}
+              disabled={isUpdatePending}
+              className='focus:ring-0 focus:ring-offset-0'
+            >
+              저장
+            </Button>
+            <Button
+              size='xs'
+              onClick={handleCancelEdit}
+              className='text-black-700 bg-blue-200 hover:bg-blue-200 focus:ring-0 focus:ring-offset-0 active:border-blue-200 active:bg-blue-200'
+            >
+              취소
+            </Button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/CommentEditForm.tsx
+++ b/src/components/CommentEditForm.tsx
@@ -31,7 +31,8 @@ export default function CommentEditForm({
         <textarea
           value={editedContent}
           onChange={(e) => setEditedContent(e.target.value)}
-          className='border-black-600 text-md text-black-700 w-full resize-none rounded-lg border px-4 py-3 md:text-lg lg:text-xl'
+          placeholder='100자 이내로 입력해 주세요.'
+          className='border-black-600 text-md text-black-700 w-full resize-none rounded-lg border px-4 py-3 placeholder-blue-400 md:text-lg lg:text-xl'
         />
         <div className='flex items-center justify-between'>
           <Toggle


### PR DESCRIPTION
## ❓이슈

- close #152

## :memo: Description

1. 데이터 패칭을 `MyWritings`에서 한 번만 수행하도록 변경
    - 기존: `MyEpigrams`와 `MyComments` 각각에서 데이터를 패칭하고 있음
    - 변경: `MyWritings`에서 데이터를 패칭한 후, `props`로 하위 컴포넌트에 전달
    - 이로 인해 총 개수를 위한 별도의 `state` 관리가 필요 없어짐
2. 데이터 변경(예: 댓글 삭제)에 따라 개수가 자동으로 업데이트되도록 수정
    - `useMutation`을 사용하여 댓글을 삭제하면, 기존 데이터가 자동으로 갱신되도록 설정
    - `react-query`의 `invalidateQueries`를 활용하여 최신 상태 유지
3. `useDeleteComment` 훅으로 댓글 삭제 기능 구현
4. `useUpdateComment` 훅으로 댓글 수정 기능 구현
5. 댓글 수정 시간을 보여주기 위해 `createdAt`에서 `updatedAt`으로 변경


https://github.com/user-attachments/assets/6ddc2b5c-f4f7-49c4-9ad3-c1ea80f2611f


## :cyclone: PR Type

어떤 변경 사항이 있나요?

<!-- 해당 사항에 체크해 주세요. -->

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항 (오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

### PR

<!-- 작성중인 PR인 경우, Draft 모드로 생성해주세요. -->

- [x] Branch Convention 확인
  > `feat/*` 기능 구현, `fix/*` 버그 수정, `refactor/*` 개선
- [x] Base Branch 확인
- [x] 적절한 Label 지정
- [x] Assignee 및 Reviewer 지정
