### PR TITLE
Feat/176/댓글 프로필모달연결

### DIFF
--- a/src/components/Comment.tsx
+++ b/src/components/Comment.tsx
@@ -5,8 +5,10 @@ import formatTime from '@/utils/formatTime';
 import Avatar from './Avatar';
 import ProfileModal from './ProfileModal';
 import { cn } from '@/utils/helper';
+import { Epigram } from '@/apis/epigram/epigram.type';
 
 interface CommentProps {
+  epigramId: Epigram['id'];
   content: string;
   writer: {
     image: string;
@@ -19,6 +21,7 @@ interface CommentProps {
 }
 
 export default function Comment({
+  epigramId,
   content,
   writer,
   updatedAt,
@@ -28,9 +31,13 @@ export default function Comment({
 }: CommentProps) {
   const [isProfileModalOpen, setIsProfileModalOpen] = useState(false);
 
+  const handleCommentClick = () => {
+    window.location.href = `/epigrams/${epigramId}`;
+  };
+
   const classes = {
     commentWrapper: cn(
-      'border-line-200 flex items-start border-t px-6 py-4 text-left md:py-6 lg:py-9',
+      'border-line-200 flex items-start border-t px-6 py-4 text-left md:py-6 lg:py-9 cursor-pointer',
       className,
     ),
     commentBox: 'ml-4 flex-1',
@@ -44,8 +51,14 @@ export default function Comment({
 
   return (
     <>
-      <div className={classes.commentWrapper}>
-        <div onClick={() => setIsProfileModalOpen(true)} className='cursor-pointer'>
+      <div onClick={handleCommentClick} className={classes.commentWrapper}>
+        <div
+          onClick={(e) => {
+            e.stopPropagation();
+            setIsProfileModalOpen(true);
+          }}
+          className='cursor-pointer'
+        >
           <Avatar src={writer.image} alt={writer.nickname} />
         </div>
         <div className={classes.commentBox}>
@@ -55,16 +68,22 @@ export default function Comment({
             <ul className={classes.commentInfoBtns}>
               <li>
                 <button
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    handleEdit?.();
+                  }}
                   className={cn(classes.commentInfoBtn, 'text-black-600 decoration-black-600')}
-                  onClick={handleEdit}
                 >
                   수정
                 </button>
               </li>
               <li>
                 <button
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    handleDelete?.();
+                  }}
                   className={cn(classes.commentInfoBtn, 'text-red decoration-red')}
-                  onClick={handleDelete}
                 >
                   삭제
                 </button>

--- a/src/components/Comment.tsx
+++ b/src/components/Comment.tsx
@@ -1,7 +1,9 @@
 'use client';
 
+import { useState } from 'react';
 import formatTime from '@/utils/formatTime';
 import Avatar from './Avatar';
+import ProfileModal from './ProfileModal';
 import { cn } from '@/utils/helper';
 
 interface CommentProps {
@@ -24,6 +26,8 @@ export default function Comment({
   handleEdit,
   handleDelete,
 }: CommentProps) {
+  const [isProfileModalOpen, setIsProfileModalOpen] = useState(false);
+
   const classes = {
     commentWrapper: cn(
       'border-line-200 flex items-start border-t px-6 py-4 text-left md:py-6 lg:py-9',
@@ -39,33 +43,43 @@ export default function Comment({
   };
 
   return (
-    <div className={classes.commentWrapper}>
-      <Avatar src={writer.image} alt={writer.nickname} />
-      <div className={classes.commentBox}>
-        <div className={classes.commentInfo}>
-          <div className={classes.commentInfoText}>{writer.nickname}</div>
-          <div className={cn(classes.commentInfoText, 'ml-2')}>{formatTime(updatedAt)}</div>
-          <ul className={classes.commentInfoBtns}>
-            <li>
-              <button
-                className={cn(classes.commentInfoBtn, 'text-black-600 decoration-black-600')}
-                onClick={handleEdit}
-              >
-                수정
-              </button>
-            </li>
-            <li>
-              <button
-                className={cn(classes.commentInfoBtn, 'text-red decoration-red')}
-                onClick={handleDelete}
-              >
-                삭제
-              </button>
-            </li>
-          </ul>
+    <>
+      <div className={classes.commentWrapper}>
+        <div onClick={() => setIsProfileModalOpen(true)} className='cursor-pointer'>
+          <Avatar src={writer.image} alt={writer.nickname} />
         </div>
-        <div className={classes.commentContent}>{content}</div>
+        <div className={classes.commentBox}>
+          <div className={classes.commentInfo}>
+            <div className={classes.commentInfoText}>{writer.nickname}</div>
+            <div className={cn(classes.commentInfoText, 'ml-2')}>{formatTime(updatedAt)}</div>
+            <ul className={classes.commentInfoBtns}>
+              <li>
+                <button
+                  className={cn(classes.commentInfoBtn, 'text-black-600 decoration-black-600')}
+                  onClick={handleEdit}
+                >
+                  수정
+                </button>
+              </li>
+              <li>
+                <button
+                  className={cn(classes.commentInfoBtn, 'text-red decoration-red')}
+                  onClick={handleDelete}
+                >
+                  삭제
+                </button>
+              </li>
+            </ul>
+          </div>
+          <div className={classes.commentContent}>{content}</div>
+        </div>
       </div>
-    </div>
+
+      <ProfileModal
+        isOpen={isProfileModalOpen}
+        writer={writer}
+        onClose={() => setIsProfileModalOpen(false)}
+      />
+    </>
   );
 }

--- a/src/hooks/useModal.ts
+++ b/src/hooks/useModal.ts
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 
-const useModal = (isOpen: boolean, onClose: () => void) => {
+export default function useModal(isOpen: boolean, onClose: () => void) {
   const [mounted, setMounted] = useState(false);
 
   useEffect(() => {
@@ -20,31 +20,55 @@ const useModal = (isOpen: boolean, onClose: () => void) => {
       }
     };
 
-    if (isOpen) {
-      window.addEventListener('keydown', handleKeyDown);
-      window.addEventListener('click', handleClickOutside);
+    const getScrollbarWidth = () => window.innerWidth - document.documentElement.clientWidth;
 
-      const scrollBarWidth = window.innerWidth - document.body.clientWidth;
-      if (scrollBarWidth > 0) {
-        document.body.style.paddingRight = `${scrollBarWidth}px`;
-      }
+    const getFixedElements = () => {
+      return Array.from(document.querySelectorAll<HTMLElement>('*')).filter(
+        (el) => getComputedStyle(el).position === 'fixed',
+      );
+    };
+
+    if (isOpen) {
+      const scrollbarWidth = getScrollbarWidth();
+      const fixedElements = getFixedElements();
 
       document.body.style.overflow = 'hidden';
+      document.body.style.paddingRight = `${scrollbarWidth}px`;
+
+      fixedElements.forEach((el) => {
+        el.style.paddingRight = `${scrollbarWidth}px`;
+      });
+
+      window.addEventListener('keydown', handleKeyDown);
+      window.addEventListener('click', handleClickOutside);
     } else {
+      const fixedElements = getFixedElements();
+
+      document.body.style.overflow = '';
+      document.body.style.paddingRight = '';
+
+      fixedElements.forEach((el) => {
+        el.style.paddingRight = '';
+      });
+
       window.removeEventListener('keydown', handleKeyDown);
       window.removeEventListener('click', handleClickOutside);
-      document.body.style.paddingRight = '0';
-      document.body.style.overflow = 'auto';
     }
 
     return () => {
+      const fixedElements = getFixedElements();
+
+      document.body.style.overflow = '';
+      document.body.style.paddingRight = '';
+
+      fixedElements.forEach((el) => {
+        el.style.paddingRight = '';
+      });
+
       window.removeEventListener('keydown', handleKeyDown);
       window.removeEventListener('click', handleClickOutside);
-      document.body.style.paddingRight = '0';
-      document.body.style.overflow = 'auto';
     };
   }, [isOpen, onClose]);
-  return { mounted };
-};
 
-export default useModal;
+  return { mounted };
+}


### PR DESCRIPTION
## ❓이슈

- close #176 

## :memo: Description
- 댓글 프로필 이미지 클릭 시 프로필 모달 연결
- 댓글 클릭 시 상세페이지로 이동
- 댓글 수정/삭제 낙관적 업데이트 패턴 개선
  - `onMutate`에서
      - 현재 데이터를 스냅샷으로 저장 (롤백 대비)
      - UI를 먼저 업데이트 (빠른 반응성)
  - `onError`에서
      - 요청이 실패하면 저장해둔 스냅샷 데이터를 사용해 원래 상태로 복구
  - `onSettled`에서
      - 최종적으로 `invalidateQueries`를 실행하여 서버 데이터와 동기화

## :cyclone: PR Type

어떤 변경 사항이 있나요?

<!-- 해당 사항에 체크해 주세요. -->

- [x] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항 (오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

### PR

<!-- 작성중인 PR인 경우, Draft 모드로 생성해주세요. -->

- [x] Branch Convention 확인
  > `feat/*` 기능 구현, `fix/*` 버그 수정, `refactor/*` 개선
- [x] Base Branch 확인
- [x] 적절한 Label 지정
- [x] Assignee 및 Reviewer 지정
