### PR TITLE
Bug/207/리프레시 토큰 개선

### DIFF
--- a/src/context/AuthSession.tsx
+++ b/src/context/AuthSession.tsx
@@ -22,9 +22,15 @@ function RefreshErrorWatcher() {
   const pathname = usePathname();
 
   useEffect(() => {
-    if (pathname !== '/login' && session?.error === 'RefreshTokenError') {
-      signOut({ callbackUrl: '/login' });
-    }
+    (async function handleSignOut() {
+      if (pathname !== '/login' && session?.error === 'RefreshTokenError') {
+        // nextauth client api 이용하여, cookie 안전하게 삭제
+        await signOut({ redirect: false });
+
+        // nextjs middleware에게 다시 페이지 검증요청
+        window.location.reload();
+      }
+    })();
   }, [session, pathname]);
 
   return null;

--- a/src/context/AuthSession.tsx
+++ b/src/context/AuthSession.tsx
@@ -1,11 +1,31 @@
 'use client';
 
-import { SessionProvider } from 'next-auth/react';
+import { useEffect } from 'react';
+import { usePathname } from 'next/navigation';
+import { SessionProvider, signOut, useSession } from 'next-auth/react';
 
 type Props = {
   children: React.ReactNode;
 };
 
 export default function AuthSession({ children }: Props) {
-  return <SessionProvider>{children}</SessionProvider>;
+  return (
+    <SessionProvider>
+      <RefreshErrorWatcher />
+      {children}
+    </SessionProvider>
+  );
+}
+
+function RefreshErrorWatcher() {
+  const { data: session } = useSession();
+  const pathname = usePathname();
+
+  useEffect(() => {
+    if (pathname !== '/login' && session?.error === 'RefreshTokenError') {
+      signOut({ callbackUrl: '/login' });
+    }
+  }, [session, pathname]);
+
+  return null;
 }

--- a/src/utils/nextauth.ts
+++ b/src/utils/nextauth.ts
@@ -1,5 +1,6 @@
 import { isAxiosError } from 'axios';
 import { AuthOptions } from 'next-auth';
+import { redirect } from 'next/navigation';
 import { jwtDecode } from 'jwt-decode';
 import CredentialsProvider from 'next-auth/providers/credentials';
 import { googleSignIn, kakaoSignIn, refreshAccessToken, signIn } from '@/apis/auth/auth.service';
@@ -119,6 +120,7 @@ export const authOptions: AuthOptions = {
         } catch (error) {
           console.error('토큰 갱신 실패:', error);
           token.error = 'RefreshTokenError';
+          redirect('/login');
         }
       }
 

--- a/src/utils/nextauth.ts
+++ b/src/utils/nextauth.ts
@@ -120,7 +120,6 @@ export const authOptions: AuthOptions = {
         } catch (error) {
           console.error('토큰 갱신 실패:', error);
           token.error = 'RefreshTokenError';
-          redirect('/login');
         }
       }
 


### PR DESCRIPTION
## ❓이슈

- close #207

## :memo: Description

<!-- 어떤 내용의 PR인지 작성해 주세요. (ex. 메인 페이지 레이아웃 작업) -->
<!-- ⚠️ PR에는 해당 PR의 제목에 해당하는 내용만 들어가 있어야 합니다!  -->
### 작업내용
nextauth config의 jwt callback안에서, 유효기간이 지난 accessToken이 있을시에
토큰을 재발급하는 과정에서 실패가 발생하면, token.error에 에러문구를 담고, 클라이언트 사이드에서 체크후 리다이렉션를 합니다.

### 수정된 Session Provider
```tsx
'use client';

import { useEffect } from 'react';
import { usePathname } from 'next/navigation';
import { SessionProvider, signOut, useSession } from 'next-auth/react';

type Props = {
  children: React.ReactNode;
};

export default function AuthSession({ children }: Props) {
  return (
    <SessionProvider>
      <RefreshErrorWatcher />
      {children}
    </SessionProvider>
  );
}

function RefreshErrorWatcher() {
  const { data: session } = useSession();
  const pathname = usePathname();

  useEffect(() => {
    (async function handleSignOut() {
      if (pathname !== '/login' && session?.error === 'RefreshTokenError') {
        // nextauth client api 이용하여, cookie 안전하게 삭제
        await signOut({ redirect: false });

        // nextjs middleware에게 다시 페이지 검증요청
        window.location.reload();
      }
    })();
  }, [session, pathname]);

  return null;
}

```

### 왜 서버 코드에서 redirect()를 사용하지 않는가

NextAuth의 config는 Next.js App Router의 route handler를 통해 실행되기 때문에 이론적으로는 서버 사이드에서 redirect()를 바로 호출할 수도 있습니다.

하지만 안전한 로그아웃 처리를 위해, 클라이언트에서 제공하는 signOut() 함수를 사용하여 사용자 브라우저의 세션 쿠키를 명시적으로 삭제하도록 처리했습니다.

> signOut()은 내부적으로 /api/auth/signout 및 /api/auth/csrf 엔드포인트를 호출해 쿠키를 삭제합니다.
https://next-auth.js.org/getting-started/rest-api#post-apiauthsignout

> nextauth v4의 공식문서에서도 client side에서 session.error의 값을 읽고, signOut을 호출하는 방법을 씁니다.
https://next-auth.js.org/v3/tutorials/refresh-token-rotation#client-side

### signOut에 await을 붙이고 강제 새로고침을 한 이유

signOut() 함수는 내부적으로 비동기 요청을 보내 쿠키를 삭제하고, 이후 자동으로 브라우저를 리다이렉션합니다.
하지만 쿠키 삭제와 리다이렉션이 완전히 순차적으로 보장되지 않기 때문에, 이 사이에 문제가 발생할 수 있습니다.

저희 프로젝트는 인증이 필요한 페이지 접근 시, middleware가 작동하도록 되어 있습니다. 그런데 이 과정에서 브라우저가 새로고침되는 순간,
쿠키 삭제가 아직 완료되지 않았다면, middleware는 세션이 존재한다고 판단하여 잘못된 리다이렉션이 발생할 수 있습니다.

이를 방지하기 위해 아래와 같은 flow를 선택했습니다.

- signOut({ redirect: false }) 옵션으로 자동 리디렉트를 끄고
- signOut()이 완료될 때까지 await로 대기한 뒤
- 직접 브라우저를 새로고침(window.location.reload()) 하도록 처리했습니다
- 새로고침되면서 middleware가 작동하여, 안전하게 페이지 리다이렉션을 처리합니다.

## :cyclone: PR Type

어떤 변경 사항이 있나요?

<!-- 해당 사항에 체크해 주세요. -->

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항 (오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

### PR

<!-- 작성중인 PR인 경우, Draft 모드로 생성해주세요. -->

- [x] Branch Convention 확인
  > `feat/*` 기능 구현, `fix/*` 버그 수정, `refactor/*` 개선
- [x] Base Branch 확인
- [x] 적절한 Label 지정
- [x] Assignee 및 Reviewer 지정
