### PR TITLE
Bug/209/댓글더보기개수변경

### DIFF
--- a/src/apis/comment/comment.queries.ts
+++ b/src/apis/comment/comment.queries.ts
@@ -3,12 +3,14 @@ import { getComments, deleteComment, updateComment, createComment } from './comm
 import { PaginationQueryParams } from '@/types/common';
 import { Comment, UpdateCommentFormType } from './comment.type';
 
-export const useCommentsInfiniteQuery = (params: Omit<PaginationQueryParams, 'cursor'>) => {
+export const useCommentsInfiniteQuery = (initialLimit: number, fetchLimit: number) => {
   return useInfiniteQuery({
-    queryKey: ['comments', params],
-    queryFn: ({ pageParam }: { pageParam?: number }) =>
-      getComments({ ...params, cursor: pageParam }),
-    initialPageParam: undefined,
+    queryKey: ['comments', { initialLimit, fetchLimit }],
+    queryFn: ({ pageParam = 0 }) => {
+      const limit = pageParam === 0 ? initialLimit : fetchLimit;
+      return getComments({ cursor: pageParam, limit });
+    },
+    initialPageParam: 0,
     getNextPageParam: (lastPage) => lastPage.nextCursor || undefined,
   });
 };
@@ -100,16 +102,4 @@ export const useUpdateComment = () => {
 
 export const createEpigramComment = (epigramId: number, content: string, isPrivate: boolean) => {
   return createComment({ epigramId, content, isPrivate });
-};
-
-export const useCustomCommentsInfiniteQuery = (initialLimit: number, fetchLimit: number) => {
-  return useInfiniteQuery({
-    queryKey: ['customComments', { initialLimit, fetchLimit }],
-    queryFn: ({ pageParam = 0 }) => {
-      const limit = pageParam === 0 ? initialLimit : fetchLimit;
-      return getComments({ cursor: pageParam, limit });
-    },
-    initialPageParam: 0,
-    getNextPageParam: (lastPage) => lastPage.nextCursor || undefined,
-  });
 };

--- a/src/apis/comment/comment.queries.ts
+++ b/src/apis/comment/comment.queries.ts
@@ -101,3 +101,15 @@ export const useUpdateComment = () => {
 export const createEpigramComment = (epigramId: number, content: string, isPrivate: boolean) => {
   return createComment({ epigramId, content, isPrivate });
 };
+
+export const useCustomCommentsInfiniteQuery = (initialLimit: number, fetchLimit: number) => {
+  return useInfiniteQuery({
+    queryKey: ['customComments', { initialLimit, fetchLimit }],
+    queryFn: ({ pageParam = 0 }) => {
+      const limit = pageParam === 0 ? initialLimit : fetchLimit;
+      return getComments({ cursor: pageParam, limit });
+    },
+    initialPageParam: 0,
+    getNextPageParam: (lastPage) => lastPage.nextCursor || undefined,
+  });
+};

--- a/src/app/(after-login)/epigrams/_components/RecentComment.tsx
+++ b/src/app/(after-login)/epigrams/_components/RecentComment.tsx
@@ -2,7 +2,7 @@
 
 import React, { useState } from 'react';
 import {
-  useCustomCommentsInfiniteQuery,
+  useCommentsInfiniteQuery,
   useDeleteComment,
   useUpdateComment,
 } from '@/apis/comment/comment.queries';
@@ -21,7 +21,7 @@ import { useQueryClient } from '@tanstack/react-query';
 
 export default function RecentComment() {
   const queryClient = useQueryClient();
-  const { data, isFetching, hasNextPage, fetchNextPage } = useCustomCommentsInfiniteQuery(3, 4);
+  const { data, isFetching, hasNextPage, fetchNextPage } = useCommentsInfiniteQuery(3, 4);
   const { data: session } = useSession();
 
   const comments = data?.pages.flatMap((page) => page.list) ?? [];

--- a/src/app/(after-login)/epigrams/_components/RecentComment.tsx
+++ b/src/app/(after-login)/epigrams/_components/RecentComment.tsx
@@ -2,7 +2,7 @@
 
 import React, { useState } from 'react';
 import {
-  useCommentsInfiniteQuery,
+  useCustomCommentsInfiniteQuery,
   useDeleteComment,
   useUpdateComment,
 } from '@/apis/comment/comment.queries';
@@ -21,7 +21,7 @@ import { useQueryClient } from '@tanstack/react-query';
 
 export default function RecentComment() {
   const queryClient = useQueryClient();
-  const { data, isFetching, hasNextPage, fetchNextPage } = useCommentsInfiniteQuery({ limit: 3 });
+  const { data, isFetching, hasNextPage, fetchNextPage } = useCustomCommentsInfiniteQuery(3, 4);
   const { data: session } = useSession();
 
   const comments = data?.pages.flatMap((page) => page.list) ?? [];


### PR DESCRIPTION
## ❓이슈

- close #209 

## :memo: Description

**작업 내용**
- 최신 댓글 더보기 개수 3 -> 4로 수정했습니다.
~~`useCustomCommentsInfiniteQuery` 훅을 추가해서 수정했습니다.~~ 
ㄴ> 기존 `useCommentsInfiniteQuery`를 수정했습니다.

```js
export const useCommentsInfiniteQuery = (initialLimit: number, fetchLimit: number) => {
  return useInfiniteQuery({
    queryKey: ['customComments', { initialLimit, fetchLimit }],
    queryFn: ({ pageParam = 0 }) => {
      const limit = pageParam === 0 ? initialLimit : fetchLimit;
      return getComments({ cursor: pageParam, limit });
    },
    initialPageParam: 0,
    getNextPageParam: (lastPage) => lastPage.nextCursor || undefined,
  });
};
```
초기 보여지는 댓글 3개, 이후 더보기 클릭 시는 4개씩 보여지는 로직을 구현하기 위해 쿼리 훅을 추가해서 구현했습니다.
 `const limit = pageParam === 0 ? initialLimit : fetchLimit;`
초기 값인 경우 initialLimit(3), 이후 fetchLimit(4)


**초기 시도했던 방법**
```js
const [limit, setLimit] = useState(INITIAL_LIMIT);  // 초기값: 3
const { data, fetchNextPage } = useCommentsInfiniteQuery({ limit });

const handleLoadMore = () => {
  setLimit(LOAD_MORE_LIMIT); // 4
  fetchNextPage();
};
```
리액트 쿼리의 키가 고정된 상태에서 limit을 변경해도 기존 유지가 되기 때문에 원하던 방식인 3->7->11 이 아닌 3->4->8 이런식으로 구현이 됐습니다.


## :cyclone: PR Type

어떤 변경 사항이 있나요?

<!-- 해당 사항에 체크해 주세요. -->

- [x] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항 (오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

### PR

<!-- 작성중인 PR인 경우, Draft 모드로 생성해주세요. -->

- [x] Branch Convention 확인
  > `feat/*` 기능 구현, `fix/*` 버그 수정, `refactor/*` 개선
- [x] Base Branch 확인
- [x] 적절한 Label 지정
- [x] Assignee 및 Reviewer 지정
