### PR TITLE
Feat/210/API-Proxy개선

### DIFF
--- a/src/app/api/[...endpoint]/route.ts
+++ b/src/app/api/[...endpoint]/route.ts
@@ -2,14 +2,13 @@ import { NextRequest, NextResponse } from 'next/server';
 import axios, { Method } from 'axios';
 import { axiosServerInstance } from '@/utils/axios';
 
+const METHODS_WITHOUT_BODY = ['GET', 'DELETE', 'HEAD', 'OPTIONS'];
+const NO_BODY_STATUS = [204, 205];
+
 async function handler(req: NextRequest, method: Method) {
   const url = `${req.nextUrl.pathname.replace('/api', '')}${req.nextUrl.search}`;
-  const isFormData = req.headers.get('content-type')?.includes('multipart/form-data');
-  const isBodyAllowed = !['GET', 'DELETE', 'HEAD', 'OPTIONS'].includes(method.toUpperCase());
-
-  const body = isFormData
-    ? await req.formData().catch(() => undefined)
-    : await req.json().catch(() => ({}));
+  const isBodyAllowed = !METHODS_WITHOUT_BODY.includes(method.toUpperCase());
+  const body = await parseRequestBody(req);
 
   try {
     const response = await axiosServerInstance({
@@ -18,7 +17,16 @@ async function handler(req: NextRequest, method: Method) {
       ...(isBodyAllowed && { data: body }),
     });
 
-    return NextResponse.json(response.data, { status: response.status });
+    const status = response.status;
+    const shouldReturnEmptyBody = NO_BODY_STATUS.includes(status);
+
+    if (shouldReturnEmptyBody) {
+      return new NextResponse(null, { status });
+    }
+
+    return NextResponse.json(response.data, {
+      status,
+    });
   } catch (error) {
     if (axios.isAxiosError(error)) {
       return NextResponse.json({ error: error.message }, { status: error.response?.status || 500 });
@@ -45,4 +53,25 @@ export async function PATCH(req: NextRequest) {
 
 export async function DELETE(req: NextRequest) {
   return handler(req, 'DELETE');
+}
+
+export async function parseRequestBody(req: NextRequest): Promise<unknown> {
+  const contentType = req.headers.get('content-type') || '';
+
+  try {
+    if (contentType.includes('application/json')) {
+      return await req.json();
+    }
+
+    if (
+      contentType.includes('multipart/form-data') ||
+      contentType.includes('application/x-www-form-urlencoded')
+    ) {
+      return await req.formData();
+    }
+
+    return await req.text();
+  } catch {
+    return undefined;
+  }
 }

--- a/src/app/api/[...endpoint]/route.ts
+++ b/src/app/api/[...endpoint]/route.ts
@@ -55,7 +55,7 @@ export async function DELETE(req: NextRequest) {
   return handler(req, 'DELETE');
 }
 
-export async function parseRequestBody(req: NextRequest): Promise<unknown> {
+async function parseRequestBody(req: NextRequest): Promise<unknown> {
   const contentType = req.headers.get('content-type') || '';
 
   try {


### PR DESCRIPTION
## ❓이슈

- close #210 

## :memo: Description

<!-- 어떤 내용의 PR인지 작성해 주세요. (ex. 메인 페이지 레이아웃 작업) -->
<!-- ⚠️ PR에는 해당 PR의 제목에 해당하는 내용만 들어가 있어야 합니다!  -->
### 작업내용
기존 api proxy코드에서 204와 같은 body가 존재하지 않는 응답에 대해서, 결과를 돌려줄때 error가 발생하는 문제점을 해결했습니다.
- 특별하게 관리해야하는 케이스들을 상수화 시켜서 관리하는 방식을 변경했습니다.
- 라우터핸들러로 들어오는 요청의 body를 parse할때, 요청의 content type에 맞게 parse를 하는 함수를 분리했습니다.
- 204,205 응답에는 body가 없어야 하는 issue로 응답을 보낼때 구별하여 처리하는 케이스를 추가했습니다. (205도 바디가 없어야되는것 같네요)
https://datatracker.ietf.org/doc/html/rfc7231#section-6.3.5
https://datatracker.ietf.org/doc/html/rfc7231#section-6.3.6

### http-proxy-middleware를 쓰지 않은이유
- nextjs app router에서 사용이 안되는것 같습니다.
  - https://github.com/stegano/next-http-proxy-middleware/issues/83
  - https://github.com/chimurai/http-proxy-middleware/issues/932
  - pages router를 사용하여 적용하는 방법이 있습니다.
- 기존에 작성해둔 axios instance, interceptor를 그대로 사용하려고 합니다.

### 특별한 케이스 상수화 관리
```ts
const METHODS_WITHOUT_BODY = ['GET', 'DELETE', 'HEAD', 'OPTIONS'];
const NO_BODY_STATUS = [204, 205];
```

### 컨텐츠 타입에 맞는 parsed body 반환함수 작성
```ts
export async function parseRequestBody(req: NextRequest): Promise<unknown> {
  const contentType = req.headers.get('content-type') || '';

  try {
    if (contentType.includes('application/json')) {
      return await req.json();
    }

    if (
      contentType.includes('multipart/form-data') ||
      contentType.includes('application/x-www-form-urlencoded')
    ) {
      return await req.formData();
    }

    return await req.text();
  } catch {
    return undefined;
  }
}
```

### 204와 같이 body를 보내지 말아야하는 응답케이스 추가
```ts
try {
    const response = await axiosServerInstance({
      method,
      url,
      ...(isBodyAllowed && { data: body }),
    });

    const status = response.status;
    const shouldReturnEmptyBody = NO_BODY_STATUS.includes(status);

    if (shouldReturnEmptyBody) {
      return new NextResponse(null, { status });
    }

    return NextResponse.json(response.data, {
      status,
    });
  } catch (error) {
    if (axios.isAxiosError(error)) {
      return NextResponse.json({ error: error.message }, { status: error.response?.status || 500 });
    }
    return NextResponse.json({ error: 'An unexpected error occurred' }, { status: 500 });
  }
```
### 204 응답 케이스 테스트 결과
기존에 204로 백앤드에서 api 응답후, api proxy에서 오류발생으로 500으로 클라이언트가 응답을 받던 현상이 수정되었습니다.
(정상적으로 클라이언트에서도 204로 응답받음)
<img width="1512" alt="스크린샷 2025-03-30 오후 12 08 03" src="https://github.com/user-attachments/assets/1da87c39-918c-47e4-9aa1-d4435702e1a9" />

## :cyclone: PR Type

어떤 변경 사항이 있나요?

<!-- 해당 사항에 체크해 주세요. -->

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항 (오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

### PR

<!-- 작성중인 PR인 경우, Draft 모드로 생성해주세요. -->

- [x] Branch Convention 확인
  > `feat/*` 기능 구현, `fix/*` 버그 수정, `refactor/*` 개선
- [x] Base Branch 확인
- [x] 적절한 Label 지정
- [x] Assignee 및 Reviewer 지정
