### PR TITLE
Refactor/218/쿼리키네이밍리팩터링

### DIFF
--- a/src/apis/comment/comment.queries.ts
+++ b/src/apis/comment/comment.queries.ts
@@ -1,6 +1,5 @@
 import { useInfiniteQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { getComments, deleteComment, updateComment, createComment } from './comment.service';
-import { PaginationQueryParams } from '@/types/common';
 import { Comment, UpdateCommentFormType } from './comment.type';
 
 export const useCommentsInfiniteQuery = (initialLimit: number, fetchLimit: number) => {
@@ -21,14 +20,14 @@ export const useDeleteComment = () => {
     mutationFn: (commentId: Comment['id']) => deleteComment(commentId),
 
     onMutate: async (commentId) => {
-      await queryClient.cancelQueries({ queryKey: ['userComments'] });
+      await queryClient.cancelQueries({ queryKey: ['comments', 'user'] });
 
       const previousComments = queryClient.getQueryData<{
         pages: { list: Comment[]; nextCursor?: number }[];
-      }>(['userComments']);
+      }>(['comments', 'user']);
 
       queryClient.setQueryData<{ pages: { list: Comment[]; nextCursor?: number }[] }>(
-        ['userComments'],
+        ['comments', 'user'],
         (oldData) => {
           if (!oldData) return oldData;
           return {
@@ -46,12 +45,12 @@ export const useDeleteComment = () => {
 
     onError: (_, __, context) => {
       if (context?.previousComments) {
-        queryClient.setQueryData(['userComments'], context.previousComments);
+        queryClient.setQueryData(['comments', 'user'], context.previousComments);
       }
     },
 
     onSettled: () => {
-      queryClient.invalidateQueries({ queryKey: ['userComments'] });
+      queryClient.invalidateQueries({ queryKey: ['comments', 'user'] });
     },
   });
 };
@@ -63,14 +62,14 @@ export const useUpdateComment = () => {
       updateComment(commentId, data),
 
     onMutate: async ({ commentId, data }) => {
-      await queryClient.cancelQueries({ queryKey: ['userComments'] });
+      await queryClient.cancelQueries({ queryKey: ['comments', 'user'] });
 
       const previousComments = queryClient.getQueryData<{
         pages: { list: Comment[]; nextCursor?: number }[];
-      }>(['userComments']);
+      }>(['comments', 'user']);
 
       queryClient.setQueryData<{ pages: { list: Comment[]; nextCursor?: number }[] }>(
-        ['userComments'],
+        ['comments', 'user'],
         (oldData) => {
           if (!oldData) return oldData;
           return {
@@ -90,12 +89,12 @@ export const useUpdateComment = () => {
 
     onError: (_, __, context) => {
       if (context?.previousComments) {
-        queryClient.setQueryData(['userComments'], context.previousComments);
+        queryClient.setQueryData(['comments', 'user'], context.previousComments);
       }
     },
 
     onSettled: () => {
-      queryClient.invalidateQueries({ queryKey: ['userComments'] });
+      queryClient.invalidateQueries({ queryKey: ['comments', 'user'] });
     },
   });
 };

--- a/src/apis/emotion/emotion.queries.ts
+++ b/src/apis/emotion/emotion.queries.ts
@@ -10,7 +10,7 @@ import { format } from 'date-fns';
 
 export const useEmotionLogToday = (userId: number | null) => {
   return useQuery({
-    queryKey: ['emotionLogToday', userId],
+    queryKey: ['emotion', 'today', userId],
     queryFn: () => (userId ? getEmotionLogToday({ userId }) : Promise.resolve(null)),
     enabled: userId !== null,
     retryOnMount: false,
@@ -23,7 +23,7 @@ export const useCreateEmotionLog = (userId: number | null) => {
     mutationFn: (data: { emotion: Emotion }) => createEmotionLogToday(data),
     onSuccess: () => {
       if (userId !== null) {
-        queryClient.invalidateQueries({ queryKey: ['emotionLogToday', userId] });
+        queryClient.invalidateQueries({ queryKey: ['emotion', 'today', userId] });
       }
     },
   });
@@ -34,7 +34,7 @@ export const useEmotionLogsMonthly = (userId: number | null) => {
   const queryClient = useQueryClient();
 
   const { data = {} } = useQuery({
-    queryKey: ['emotionLogsMonthly', userId, currentMonth],
+    queryKey: ['emotion', 'monthly', userId, currentMonth],
     queryFn: async () => {
       if (!userId) return {};
 
@@ -53,7 +53,7 @@ export const useEmotionLogsMonthly = (userId: number | null) => {
 
   const refetchLogs = () => {
     if (userId) {
-      queryClient.invalidateQueries({ queryKey: ['emotionLogsMonthly', userId] });
+      queryClient.invalidateQueries({ queryKey: ['emotion', 'monthly', userId, currentMonth] });
     }
   };
 

--- a/src/apis/epigram/epigram.queries.ts
+++ b/src/apis/epigram/epigram.queries.ts
@@ -128,7 +128,7 @@ export const useEpigram = (epigramId: Epigram['id']) => {
 
 export const useTodayEpigram = () => {
   return useQuery({
-    queryKey: ['todayEpigram'],
+    queryKey: ['epigrams', 'today'],
     queryFn: getTodayEpigram,
     retryOnMount: false,
   });
@@ -139,7 +139,7 @@ export const useFeedCommentsInFiniteQuery = (
   params: Omit<PaginationQueryParams, 'cursor'>,
 ) => {
   return useInfiniteQuery({
-    queryKey: ['comments', epigramId, params],
+    queryKey: ['comments', 'epigrams', epigramId, params],
     queryFn: ({ pageParam }: { pageParam?: number }) =>
       getEpigramComments(epigramId, { ...params, cursor: pageParam }),
     initialPageParam: undefined,

--- a/src/apis/user/user.queries.ts
+++ b/src/apis/user/user.queries.ts
@@ -6,7 +6,7 @@ export const useUserCommentsByIdInFiniteQuery = (
   params: Omit<PaginationQueryParams, 'cursor'> & { userId: number },
 ) => {
   return useInfiniteQuery({
-    queryKey: ['userComments', params],
+    queryKey: ['comments', 'user', params.userId, params],
     queryFn: ({ pageParam }: { pageParam: number | undefined }) =>
       getUserCommentsById(params.userId, { ...params, cursor: pageParam }),
     initialPageParam: undefined,


### PR DESCRIPTION
## ❓이슈

- close #218 

## :memo: Description

**작업내용**

- 전체 쿼리 키 리팩토링
- **comment**
  - 'comments' 도메인으로 통일
  - 'userComments' -> 'comments', 'user'
- **emotion**
  - 'emotion' 도메인으로 통일
  - 'emotionLogToday' -> 'emotion', 'today'
  - 'emotionMonthly' -> 'emotion', 'monthly'
    - useEmotionLogsMonthly 훅 쿼리키에 currentMonth 추가   
- **epigram**
  - 'epigrams' 도메인으로 통일
  - 'epigramToday' -> 'epgirams', 'today'
- **user**
  - 'userComment' -> 'comments', 'user'

## :cyclone: PR Type

어떤 변경 사항이 있나요?

<!-- 해당 사항에 체크해 주세요. -->

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항 (오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

### PR

<!-- 작성중인 PR인 경우, Draft 모드로 생성해주세요. -->

- [x] Branch Convention 확인
  > `feat/*` 기능 구현, `fix/*` 버그 수정, `refactor/*` 개선
- [x] Base Branch 확인
- [x] 적절한 Label 지정
- [x] Assignee 및 Reviewer 지정
