### PR TITLE
Bug/227/이중 제출 방지

### DIFF
--- a/src/apis/comment/comment.queries.ts
+++ b/src/apis/comment/comment.queries.ts
@@ -99,6 +99,25 @@ export const useUpdateComment = () => {
   });
 };
 
-export const createEpigramComment = (epigramId: number, content: string, isPrivate: boolean) => {
-  return createComment({ epigramId, content, isPrivate });
+export const useCreateComment = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({
+      epigramId,
+      content,
+      isPrivate,
+    }: {
+      epigramId: number;
+      content: string;
+      isPrivate: boolean;
+    }) => createComment({ epigramId, content, isPrivate }),
+
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['comments', 'user'] });
+    },
+
+    onError: (error) => {
+      console.error('댓글 생성 실패:', error);
+    },
+  });
 };

--- a/src/app/(after-login)/epigrams/[id]/edit/page.tsx
+++ b/src/app/(after-login)/epigrams/[id]/edit/page.tsx
@@ -2,16 +2,17 @@
 
 import { use } from 'react';
 import { useRouter } from 'next/navigation';
-import { useQuery, useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useSession } from 'next-auth/react';
 import { toast } from 'react-toastify';
-import { getEpigramDetails, updateEpigram } from '@/apis/epigram/epigram.service';
+import { updateEpigram } from '@/apis/epigram/epigram.service';
 import { CreateEpigramFormType } from '@/apis/epigram/epigram.type';
 import Spinner from '@/components/Spinner';
 import { Section } from '@/components/Section';
 import ErrorPage from '@/app/error';
 import EpigramForm from '../../_components/EpigramForm';
 import Inner from '@/components/Inner';
+import { useEpigram } from '@/apis/epigram/epigram.queries';
 
 interface EditEpigramPageProps {
   params: Promise<{ id: string }>;
@@ -20,27 +21,32 @@ interface EditEpigramPageProps {
 export default function EditEpigramPage({ params }: EditEpigramPageProps) {
   const router = useRouter();
   const { id } = use(params);
-
   const { data: session } = useSession();
   const sessionUserId = session?.user?.id;
+  const queryClient = useQueryClient();
+  const epigramId = Number(id);
 
-  const { data, isLoading, isError } = useQuery({
-    queryKey: ['epigram', id],
-    queryFn: async () => await getEpigramDetails(Number(id)),
-    enabled: !!id,
-    retry: false,
+  const { details } = useEpigram(epigramId);
+  const data = details.data;
+  const isLoading = details.isLoading;
+  const isError = details.isError;
+
+  const { mutateAsync, isPending } = useMutation({
+    mutationFn: (data: CreateEpigramFormType) => updateEpigram(epigramId, data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['epigrams'] });
+    },
   });
 
-  const { mutate, isPending } = useMutation({
-    mutationFn: (data: CreateEpigramFormType) => updateEpigram(Number(id), data),
-    onSuccess: () => {
+  const handleUpdate = async (formData: CreateEpigramFormType) => {
+    try {
+      await mutateAsync(formData);
       toast.success('에피그램이 수정되었습니다.');
       router.push(`/epigrams/${id}`);
-    },
-    onError: () => {
+    } catch {
       toast.error('에피그램 수정에 실패했습니다.');
-    },
-  });
+    }
+  };
 
   if (isLoading)
     return (
@@ -48,11 +54,10 @@ export default function EditEpigramPage({ params }: EditEpigramPageProps) {
         <Spinner className='w-10 fill-black text-gray-100' />
       </div>
     );
-  if (isError || !data) return <ErrorPage error={new Error('에피그램을 불러오지 못했습니다.')} />;
 
-  if (data.writerId !== sessionUserId) {
+  if (isError || !data) return <ErrorPage error={new Error('에피그램을 불러오지 못했습니다.')} />;
+  if (data.writerId !== sessionUserId)
     return <ErrorPage error={new Error('수정 권한이 없습니다.')} />;
-  }
 
   return (
     <Inner className='p-6 lg:py-8'>
@@ -63,8 +68,8 @@ export default function EditEpigramPage({ params }: EditEpigramPageProps) {
           ...data,
           tags: data.tags.map((tag) => tag.name),
         }}
-        onSubmit={(formData: CreateEpigramFormType) => mutate(formData)}
         isSubmitting={isPending}
+        onSubmit={handleUpdate}
       />
     </Inner>
   );

--- a/src/app/(after-login)/epigrams/_components/EpigramComments.tsx
+++ b/src/app/(after-login)/epigrams/_components/EpigramComments.tsx
@@ -7,7 +7,7 @@ import { toast } from 'react-toastify';
 import CommentForm from '@/components/CommentForm';
 import { useQueryClient } from '@tanstack/react-query';
 import { useSession } from 'next-auth/react';
-import { createEpigramComment } from '@/apis/comment/comment.queries';
+import { useCreateComment } from '@/apis/comment/comment.queries';
 import { FormProvider, useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import type { FieldErrors } from 'react-hook-form';
@@ -36,17 +36,28 @@ export default function EpigramComments({ id }: EpigramCommentsProps) {
     fetchNextPage: fetchNextCommentPage,
   } = useFeedCommentsInFiniteQuery(id, commentQueryParams);
 
+  const { mutate: createComment, isPending: isCreatePending } = useCreateComment();
+
   const comments = commentData?.pages.flatMap((page) => page.list) ?? [];
 
-  const handleCreateComment = async (data: CommentFormValues) => {
-    try {
-      await createEpigramComment(id, data.content.trim(), data.isPrivate);
-      toast.success('댓글이 등록되었습니다');
-      methods.reset();
-      queryClient.invalidateQueries({ queryKey: ['comments'] });
-    } catch (error) {
-      toast.error('댓글 등록에 실패했습니다');
-    }
+  const handleCreateComment = (data: CommentFormValues) => {
+    createComment(
+      {
+        epigramId: id,
+        content: data.content.trim(),
+        isPrivate: data.isPrivate,
+      },
+      {
+        onSuccess: () => {
+          toast.success('댓글이 생성되었습니다.');
+          methods.reset();
+          queryClient.invalidateQueries({ queryKey: ['comments'] });
+        },
+        onError: () => {
+          toast.error('댓글 생성에 실패했습니다.');
+        },
+      },
+    );
   };
 
   const handleCreateError = (errors: FieldErrors<CommentFormValues>) => {
@@ -71,7 +82,7 @@ export default function EpigramComments({ id }: EpigramCommentsProps) {
                 ? { nickname: session.user.nickname, image: session.user.image }
                 : { nickname: '', image: '' }
             }
-            isUpdatePending={false}
+            isUpdatePending={isCreatePending}
             handleSaveEdit={() => {}}
             handleCancelEdit={() => methods.reset()}
           />

--- a/src/app/(after-login)/epigrams/_components/EpigramComments.tsx
+++ b/src/app/(after-login)/epigrams/_components/EpigramComments.tsx
@@ -43,7 +43,7 @@ export default function EpigramComments({ id }: EpigramCommentsProps) {
       await createEpigramComment(id, data.content.trim(), data.isPrivate);
       toast.success('댓글이 등록되었습니다');
       methods.reset();
-      queryClient.invalidateQueries({ queryKey: ['comments', id, commentQueryParams] });
+      queryClient.invalidateQueries({ queryKey: ['comments'] });
     } catch (error) {
       toast.error('댓글 등록에 실패했습니다');
     }

--- a/src/app/(after-login)/epigrams/_components/EpigramForm.tsx
+++ b/src/app/(after-login)/epigrams/_components/EpigramForm.tsx
@@ -40,6 +40,7 @@ export default function EpigramForm({
   isSubmitting = false,
 }: EpigramFormProps) {
   const {
+    reset,
     register,
     watch,
     setValue,
@@ -89,6 +90,7 @@ export default function EpigramForm({
     };
 
     onSubmit(payload);
+    reset();
   };
 
   const handleTagKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {

--- a/src/app/(after-login)/epigrams/create/page.tsx
+++ b/src/app/(after-login)/epigrams/create/page.tsx
@@ -8,28 +8,33 @@ import { CreateEpigramFormType } from '@/apis/epigram/epigram.type';
 import { Section } from '@/components/Section';
 import EpigramForm from '../_components/EpigramForm';
 import Inner from '@/components/Inner';
+import { useForm } from 'react-hook-form';
 
 export default function Page() {
   const router = useRouter();
-  const { mutate, isPending } = useMutation({
+  const { mutateAsync, isPending } = useMutation({
     mutationFn: createEpigram,
-    onSuccess: (data) => {
-      toast.success('에피그램이 작성되었습니다.');
-      router.push(`/epigrams/${data.id}`);
-    },
-    onError: (error) => {
-      console.error('에피그램 작성 실패:', error);
-      toast.error('에피그램 작성에 실패했습니다.');
-    },
   });
+  const methods = useForm();
+  const { reset } = methods;
 
   return (
     <Inner className='p-6 lg:py-8'>
       <Section>에피그램 만들기</Section>
       <EpigramForm
         mode='create'
-        onSubmit={(data: CreateEpigramFormType) => mutate(data)}
         isSubmitting={isPending}
+        onSubmit={async (data: CreateEpigramFormType) => {
+          try {
+            const result = await mutateAsync(data);
+            toast.success('에피그램이 작성되었습니다.');
+            reset();
+            router.push(`/epigrams/${result.id}`);
+          } catch (error) {
+            console.error('에피그램 작성 실패:', error);
+            toast.error('에피그램 작성에 실패했습니다.');
+          }
+        }}
       />
     </Inner>
   );


### PR DESCRIPTION
## ❓이슈

- close #277

## :memo: Description

### 이중 제출 방지 처리
![z](https://github.com/user-attachments/assets/de767b0a-d8d4-446f-bb8b-3af50cd62c53)
- 작성 및 수정 기능에서 빠르게 버튼을 두 번 클릭할 경우 이중 요청이 발생하던 문제발생
- react-query의 useMutation 훅 isPending 상태 활용
- isPending === true인 동안 onSubmit 실행은 무시되고, 버튼도 disabled 상태가 됨

```tsx
// 예시
const { mutateAsync, isPending } = useMutation({
  mutationFn: (data) => createOrUpdateEpigram(data),
});

<EpigramForm
  onSubmit={async (data) => {
    try {
      await mutateAsync(data);
      router.push(...);
    } catch {
      toast.error('작업에 실패했습니다.');
    }
  }}
  isSubmitting={isPending}
/>

// EpigramForm 내부
<Button type="submit" disabled={!isValid || isSubmitting}>
  {isSubmitting ? <Spinner /> : '작성 완료'}
</Button>
```

<br />

### 에피그램 작성 성공 시 리셋
- 에피그램 작성 완료 후 폼 입력값을 초기화하기 위해 react-hook-form의 reset()을 사용
- onSuccess 콜백에서 reset()을 호출함으로써 작성 성공 시 모든 입력 필드를 초기화
- 사용자는 작성 후에도 이전 입력값이 남지 않아 새로운 작성 흐름을 방해받지 않음

```tsx
// 예시
onSuccess: () => {
  reset();
  toast.success('에피그램이 작성되었습니다.');
  router.push(...);
}
```

<!-- 어떤 내용의 PR인지 작성해 주세요. (ex. 메인 페이지 레이아웃 작업) -->
<!-- ⚠️ PR에는 해당 PR의 제목에 해당하는 내용만 들어가 있어야 합니다!  -->

## :cyclone: PR Type

어떤 변경 사항이 있나요?

<!-- 해당 사항에 체크해 주세요. -->

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항 (오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

### PR

<!-- 작성중인 PR인 경우, Draft 모드로 생성해주세요. -->

- [ ] Branch Convention 확인
  > `feat/*` 기능 구현, `fix/*` 버그 수정, `refactor/*` 개선
- [ ] Base Branch 확인
- [ ] 적절한 Label 지정
- [ ] Assignee 및 Reviewer 지정
