### PR TITLE
Test/232/마이페이지 통합테스트

### DIFF
--- a/cypress/e2e/mypage.cy.ts
+++ b/cypress/e2e/mypage.cy.ts
@@ -1,0 +1,51 @@
+describe('마이페이지', () => {
+  describe('마이페이지 기본 검증', () => {
+    it('로그인이 되어있지 않으면, 로그인 페이지로 이동한다.', () => {
+      cy.visit('/mypage');
+      cy.url().should('include', `${Cypress.config().baseUrl}/login`);
+    });
+  });
+
+  describe('마이이페이지 기능 검증', () => {
+    beforeEach(() => {
+      cy.login();
+      cy.visit('/mypage');
+    });
+
+    it('초기 렌더링 시 로그아웃 버튼, 오늘의 감정, 감정 달력, 감정 차트, 내 에피그램, 내 댓글이 렌더링된다.', () => {
+      cy.contains('button', '로그아웃').should('exist');
+      cy.contains('p', '오늘의 감정').should('exist');
+      cy.contains('span', /[0-9]{4}년 [0-9]{1,2}월/).should('exist');
+      cy.contains('p', '감정 차트').should('exist');
+      cy.contains('button', '내 에피그램').should('exist');
+      cy.contains('button', '내 댓글').should('exist');
+    });
+
+    it('내 에피그램 메뉴에서 초기 4개의 에피그램이 렌더링된다.', () => {
+      cy.contains('내 에피그램')
+        .parents()
+        .find('ul')
+        .find('li')
+        .should('have.length.greaterThan', 4);
+    });
+
+    it('내 에피그램 더보기 클릭 시 추가 에피그램이 렌더링된다.', () => {
+      cy.contains('button', '내 에피그램 더보기').should('exist').click();
+      cy.contains('내 에피그램')
+        .parents()
+        .find('ul')
+        .find('li')
+        .should('have.length.greaterThan', 8);
+    });
+
+    it('내 댓글 메뉴에서 초기 4개의 댓글이 렌더링된다.', () => {
+      cy.contains('내 댓글').parents().find('ul').find('li').should('have.length.greaterThan', 4);
+    });
+
+    it('내 댓글 더보기 클릭 시 추가 댓글이 렌더링된다.', () => {
+      cy.contains('button', '내 댓글').click();
+      cy.contains('button', '내 댓글 더보기').click();
+      cy.contains('내 댓글').parents().find('ul').find('li').should('have.length.greaterThan', 8);
+    });
+  });
+});


### PR DESCRIPTION
## ❓이슈

- close #232

## :memo: Description

### 작업내용
마이페이지 통합테스트를 진행했습니다. 

<img width="1078" alt="화면 캡처 2025-04-02 123806" src="https://github.com/user-attachments/assets/936a710d-2b4b-4d47-9bd6-abf720f2e436" />

### 테스트 항목

**마이페이지 기본 검증**
- 로그인이 되어있지 않으면, 로그인 페이지로 이동한다.

**마이페이지 기능 검증**
- 초기 렌더링 시 로그아웃 버튼, 오늘의 감정, 감정 달력, 감정 차트, 내 에피그램, 내 댓글이 렌더링된다.
- 내 에피그램 메뉴에서 초기 4개의 에피그램이 렌더링된다.
- 내 에피그램 더보기 클릭 시 추가 에피그램이 렌더링된다.
- 내 댓글 메뉴에서 초기 4개의 댓글이 렌더링된다.
- 내 댓글 더보기 클릭 시 추가 댓글이 렌더링된다.

## :cyclone: PR Type

어떤 변경 사항이 있나요?

<!-- 해당 사항에 체크해 주세요. -->

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항 (오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [x] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

### PR

<!-- 작성중인 PR인 경우, Draft 모드로 생성해주세요. -->

- [x] Branch Convention 확인
  > `feat/*` 기능 구현, `fix/*` 버그 수정, `refactor/*` 개선
- [x] Base Branch 확인
- [x] 적절한 Label 지정
- [x] Assignee 및 Reviewer 지정
