### PR TITLE
 Refactor/270/ModalBase컴포넌트 제어방식확장

### DIFF
--- a/src/components/DeleteModal.tsx
+++ b/src/components/DeleteModal.tsx
@@ -1,11 +1,9 @@
 'use client';
 
-import { createPortal } from 'react-dom';
 import Image from 'next/image';
 import noticeIcon from '@/assets/img/notice.png';
-import useModal from '@/hooks/useModal';
-import { cn } from '@/utils/helper';
 import Button from './Button';
+import ModalBase from './ModalBase';
 
 interface DeleteModalProps {
   isOpen: boolean;
@@ -22,69 +20,46 @@ export default function DeleteModal({
   onClose,
   onDelete,
   isSubmitting = false,
-  className,
 }: DeleteModalProps) {
-  const { mounted } = useModal(isOpen, onClose);
-
-  const portalRoot =
-    typeof document !== 'undefined' ? document.getElementById('portal-root') : null;
-
-  if (!mounted || !portalRoot) return null;
-
-  return createPortal(
-    isOpen ? (
-      <div
-        className={cn(
-          'fixed inset-0 z-100 flex items-center justify-center bg-black/60',
-          className,
-        )}
-        onClick={onClose}
-        data-testid='modal-overlay'
-      >
-        <div
-          className='w-full max-w-[320px] rounded-3xl bg-white px-4 py-6 md:max-w-[372px] md:px-[38px] md:py-8 lg:max-w-[452px] lg:py-10'
-          onClick={(e) => e.stopPropagation()}
-        >
-          <div className='flex justify-center'>
-            <Image
-              src={noticeIcon}
-              alt='삭제 경고 아이콘'
-              width={60}
-              height={60}
-              className='h-11 w-11 lg:h-14 lg:w-14'
-            />
-          </div>
-
-          <div className='mt-4 mb-6 flex flex-col gap-2 md:mt-6 md:mb-9 lg:mb-10 lg:gap-4'>
-            <p className='text-black-700 text-center text-lg font-semibold md:text-xl lg:text-2xl'>
-              {type === 'comment' ? '댓글을 삭제하시겠어요?' : '게시물을 삭제하시겠어요?'}
-            </p>
-
-            <p className='text-md lg:text-2lg text-center text-gray-400 md:text-lg'>
-              {type === 'comment'
-                ? '댓글은 삭제 후 복구할 수 없어요.'
-                : '게시물은 삭제 후 복구할 수 없어요.'}
-            </p>
-          </div>
-
-          <div className='flex flex-row gap-2 lg:gap-4'>
-            <Button
-              onClick={onClose}
-              className='text-black-700 bg-blue-200 font-medium hover:bg-blue-200 focus:ring-0 focus:ring-offset-0 active:border-blue-200 active:bg-blue-200'
-            >
-              취소
-            </Button>
-            <Button
-              onClick={onDelete}
-              className='bg-blue-900 hover:bg-blue-950 active:bg-blue-950'
-              disabled={isSubmitting}
-            >
-              삭제하기
-            </Button>
-          </div>
-        </div>
+  return (
+    <ModalBase isOpen={isOpen} onClose={onClose} className='px-4 py-6 md:px-[38px] md:py-8'>
+      <div className='flex justify-center'>
+        <Image
+          src={noticeIcon}
+          alt='삭제 경고 아이콘'
+          width={60}
+          height={60}
+          className='h-11 w-11 lg:h-14 lg:w-14'
+        />
       </div>
-    ) : null,
-    portalRoot,
+
+      <div className='mt-4 mb-6 flex flex-col gap-2 md:mt-6 md:mb-9 lg:mb-10 lg:gap-4'>
+        <p className='text-black-700 text-center text-lg font-semibold md:text-xl lg:text-2xl'>
+          {type === 'comment' ? '댓글을 삭제하시겠어요?' : '게시물을 삭제하시겠어요?'}
+        </p>
+
+        <p className='text-md lg:text-2lg text-center text-gray-400 md:text-lg'>
+          {type === 'comment'
+            ? '댓글은 삭제 후 복구할 수 없어요.'
+            : '게시물은 삭제 후 복구할 수 없어요.'}
+        </p>
+      </div>
+
+      <div className='flex flex-row gap-2 lg:gap-4'>
+        <Button
+          onClick={onClose}
+          className='text-black-700 bg-blue-200 font-medium hover:bg-blue-200 focus:ring-0 focus:ring-offset-0 active:border-blue-200 active:bg-blue-200'
+        >
+          취소
+        </Button>
+        <Button
+          onClick={onDelete}
+          className='bg-blue-900 hover:bg-blue-950 active:bg-blue-950'
+          disabled={isSubmitting}
+        >
+          삭제하기
+        </Button>
+      </div>
+    </ModalBase>
   );
 }

--- a/src/components/ModalBase.tsx
+++ b/src/components/ModalBase.tsx
@@ -3,10 +3,27 @@
 import { createPortal } from 'react-dom';
 import useModal from '@/hooks/useModal';
 import useModalStore from '@/hooks/useModalStore';
+import { cn } from '@/utils/helper';
 
-export default function ModalBase({ children }: { children: React.ReactNode }) {
-  const { isOpen, close, type } = useModalStore();
-  const { mounted } = useModal(isOpen, close);
+interface ModalBaseProps {
+  children: React.ReactNode;
+  isOpen?: boolean;
+  onClose?: () => void;
+  className?: string;
+}
+
+export default function ModalBase({
+  children,
+  isOpen: propIsOpen,
+  onClose: propOnClose,
+  className,
+}: ModalBaseProps) {
+  const { isOpen: storeIsOpen, close: storeClose } = useModalStore();
+
+  const isOpen = propIsOpen ?? storeIsOpen;
+  const onClose = propOnClose ?? storeClose;
+
+  const { mounted } = useModal(isOpen, onClose);
 
   const portalRoot =
     typeof document !== 'undefined' ? document.getElementById('portal-root') : null;
@@ -15,11 +32,15 @@ export default function ModalBase({ children }: { children: React.ReactNode }) {
 
   return createPortal(
     <div
-      className='fixed inset-0 z-50 flex items-center justify-center bg-black/60'
-      onClick={close}
+      className={'fixed inset-0 z-50 flex items-center justify-center bg-black/60'}
+      onClick={onClose}
+      data-testid='modal-overlay'
     >
       <div
-        className='w-full max-w-[320px] rounded-3xl bg-white px-[38px] py-8 md:max-w-[372px] lg:max-w-[452px] lg:py-10'
+        className={cn(
+          'w-full max-w-[320px] rounded-3xl bg-white px-[38px] py-8 md:max-w-[372px] lg:max-w-[452px] lg:py-10',
+          className,
+        )}
         onClick={(e) => e.stopPropagation()}
       >
         {children}

--- a/src/components/ProfileModal.tsx
+++ b/src/components/ProfileModal.tsx
@@ -1,10 +1,8 @@
 'use client';
 
-import { createPortal } from 'react-dom';
-import useModal from '@/hooks/useModal';
-import { cn } from '@/utils/helper';
 import Avatar from './Avatar';
 import Icon from './Icon';
+import ModalBase from './ModalBase';
 
 interface ProfileModalProps {
   isOpen: boolean;
@@ -16,40 +14,23 @@ interface ProfileModalProps {
   className?: string;
 }
 
-export default function ProfileModal({ isOpen, writer, onClose, className }: ProfileModalProps) {
-  const { mounted } = useModal(isOpen, onClose);
-
-  const portalRoot =
-    typeof document !== 'undefined' ? document.getElementById('portal-root') : null;
-
-  if (!mounted || !portalRoot) return null;
-
-  return createPortal(
-    isOpen ? (
-      <div
-        className={cn(
-          'fixed inset-0 z-100 flex items-center justify-center bg-black/60',
-          className,
-        )}
-        onClick={onClose}
-        data-testid='modal-overlay'
-      >
-        <div
-          className='w-full max-w-[300px] rounded-3xl bg-white px-6 pt-4 pb-6 md:max-w-[328px] lg:max-w-[360px] lg:px-10 lg:pt-6 lg:pb-8'
-          onClick={(e) => e.stopPropagation()}
-        >
-          <div className='flex justify-end'>
-            <button onClick={onClose} className='cursor-pointer'>
-              <Icon name='close' size={20} />
-            </button>
-          </div>
-          <div className='mt-2 flex flex-col items-center justify-center gap-6'>
-            <Avatar src={writer.image} alt={writer.nickname} className='border border-blue-300' />
-            <p className='text-black-400 text-lg font-semibold lg:text-xl'>{writer.nickname}</p>
-          </div>
-        </div>
+export default function ProfileModal({ isOpen, writer, onClose }: ProfileModalProps) {
+  return (
+    <ModalBase
+      isOpen={isOpen}
+      onClose={onClose}
+      className='max-w-[300px] px-6 pt-4 pb-6 md:max-w-[328px] lg:max-w-[360px] lg:px-10 lg:pt-6 lg:pb-8'
+    >
+      <div className='flex justify-end'>
+        <button onClick={onClose} className='cursor-pointer'>
+          <Icon name='close' size={20} />
+        </button>
       </div>
-    ) : null,
-    portalRoot,
+
+      <div className='mt-2 flex flex-col items-center justify-center gap-6'>
+        <Avatar src={writer.image} alt={writer.nickname} className='border border-blue-300' />
+        <p className='text-black-400 text-lg font-semibold lg:text-xl'>{writer.nickname}</p>
+      </div>
+    </ModalBase>
   );
 }


### PR DESCRIPTION
## ❓이슈

- close #270 

## :memo: Description
[노션 트러블슈팅 페이지 보러가기](https://honeysuckle-watchmaker-42a.notion.site/ModalBase-props-1cd38e8296f280b0bad2e95959ad83df?pvs=4)
> 모달 컴포넌트(`ModalBase`)를 기존 전역 상태 기반 제어 방식에서 props 기반 제어 방식까지 확장하였습니다.
이를 통해 모달 사용처에서 `isOpen`, `onClose` props를 넘겨주면 독립적인 제어가 가능하며, props가 없는 경우 기존처럼 `useModalStore`를 활용하는 하이브리드 모달 방식을 지원합니다.

---

### 1. 리팩토링 배경 및 이유

- 모달 접근성 개선 작업을 위해 **모든 모달이 `ModalBase`를 공통으로 사용해야 하는 요구사항**이 생김
- 하지만 일부 모달은 전역 상태를 사용하지 않아 구조적으로 `ModalBase` 사용 불가 → 통일된 처리 어려움
- 특히 `DeleteModal`은 재사용성이 높아 전역 상태 전환 시 리팩토링 범위와 비용이 큼
    
    → **전역 상태와 props 제어를 병행 지원하는 하이브리드 구조로 `ModalBase`를 리팩토링함**

---

### 2. 주요 변경 사항

- `ModalBase`에 `isOpen`, `onClose`, `className` props를 추가
```tsx
<ModalBase isOpen={isOpen} onClose={onClose} className={className}>
  {/* content */}
</ModalBase>

```
- props 기반이 전달되면 우선적으로 사용하고, 없을 경우 기존 전역 상태(`useModalStore`)를 fallback으로 사용
```tsx
const isOpen = propIsOpen ?? storeIsOpen;
const onClose = propOnClose ?? storeClose;

```
- 전역 상태와 props 기반을 **병행 지원하는 하이브리드 방식으로 개선**
- 추후 모달 접근성 작업 시, 모든 모달이 `ModalBase`를 공통적으로 사용하도록 기반 마련
  - props로 받은 경우 → props 기반 제어 (ex. DeleteModal, ProfileModal)
  - props가 없으면 → 전역 상태 기반 제어 (ex. ProfileEditModal)

---

### 3. 리팩토링 효과

- 접근성 관련 로직(포커스트랩, aria 속성 등)을 ModalBase에 통합 적용할 수 있는 기반 마련
- 전역 상태에 의존하지 않고도 모달 재사용 가능
- 호출 지점마다 유동적인 데이터 처리 용이
- 구조 통일성 확보 → 유지보수 및 확장성 향상

---

## :cyclone: PR Type

어떤 변경 사항이 있나요?

<!-- 해당 사항에 체크해 주세요. -->

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항 (오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

### PR

<!-- 작성중인 PR인 경우, Draft 모드로 생성해주세요. -->

- [x] Branch Convention 확인
  > `feat/*` 기능 구현, `fix/*` 버그 수정, `refactor/*` 개선
- [x] Base Branch 확인
- [x] 적절한 Label 지정
- [x] Assignee 및 Reviewer 지정
