### PR TITLE
Refactor/273/유효성메시지 매직넘버 상수화

### DIFF
--- a/src/apis/auth/auth.type.ts
+++ b/src/apis/auth/auth.type.ts
@@ -1,32 +1,69 @@
 import { User } from 'next-auth';
 import { z } from 'zod';
 
+const NICKNAME_MAX_LENGTH = 20;
+const PASSWORD_MIN_LENGTH = 8;
+const PASSWORD_PATTERN = /^[a-zA-Z0-9!@#$%^&*()_+]+$/;
+
+export const AUTH_VALIDATION = {
+  EMAIL: {
+    REQUIRED_MESSAGE: '이메일은 필수 입력입니다.',
+    INVALID_MESSAGE: '이메일 형식으로 작성해 주세요.',
+  },
+  NICKNAME: {
+    REQUIRED_MESSAGE: '닉네임은 필수 입력입니다.',
+    MAX_LENGTH: NICKNAME_MAX_LENGTH,
+    MAX_MESSAGE: `닉네임은 최대 ${NICKNAME_MAX_LENGTH}자까지 가능합니다.`,
+  },
+  PASSWORD: {
+    REQUIRED_MESSAGE: '비밀번호는 필수 입력입니다.',
+    MIN_LENGTH: PASSWORD_MIN_LENGTH,
+    MIN_MESSAGE: `비밀번호는 최소 ${PASSWORD_MIN_LENGTH}자 이상입니다.`,
+    PATTERN: PASSWORD_PATTERN,
+    PATTERN_MESSAGE: '비밀번호는 숫자, 영문, 특수문자로만 가능합니다.',
+  },
+  PASSWORD_CONFIRMATION: {
+    REQUIRED_MESSAGE: '비밀번호 확인을 입력해 주세요.',
+    MISMATCH_MESSAGE: '비밀번호가 일치하지 않습니다.',
+  },
+};
+
 export const signupFormSchema = z
   .object({
-    email: z.string().min(1, '이메일은 필수 입력입니다.').email('이메일 형식으로 작성해 주세요.'),
+    email: z
+      .string()
+      .min(1, AUTH_VALIDATION.EMAIL.REQUIRED_MESSAGE)
+      .email(AUTH_VALIDATION.EMAIL.INVALID_MESSAGE),
+
     nickname: z
       .string()
-      .min(1, '닉네임은 필수 입력입니다.')
-      .max(20, '닉네임은 최대 20자까지 가능합니다.'),
+      .min(1, AUTH_VALIDATION.NICKNAME.REQUIRED_MESSAGE)
+      .max(AUTH_VALIDATION.NICKNAME.MAX_LENGTH, AUTH_VALIDATION.NICKNAME.MAX_MESSAGE),
+
     password: z.preprocess(
       (value) => (value === '' ? undefined : value),
       z
-        .string({ required_error: '비밀번호는 필수 입력입니다.' })
-        .min(8, '비밀번호는 최소 8자 이상입니다.')
-        .regex(/^[a-zA-Z0-9!@#$%^&*()_+]+$/, '비밀번호는 숫자, 영문, 특수문자로만 가능합니다.'),
+        .string({ required_error: AUTH_VALIDATION.PASSWORD.REQUIRED_MESSAGE })
+        .min(AUTH_VALIDATION.PASSWORD.MIN_LENGTH, AUTH_VALIDATION.PASSWORD.MIN_MESSAGE)
+        .regex(AUTH_VALIDATION.PASSWORD.PATTERN, AUTH_VALIDATION.PASSWORD.PATTERN_MESSAGE),
     ),
-    passwordConfirmation: z.string().min(1, '비밀번호 확인을 입력해 주세요.'),
+
+    passwordConfirmation: z.string().min(1, AUTH_VALIDATION.PASSWORD_CONFIRMATION.REQUIRED_MESSAGE),
   })
   .refine((data) => data.password === data.passwordConfirmation, {
-    message: '비밀번호가 일치하지 않습니다.',
+    message: AUTH_VALIDATION.PASSWORD_CONFIRMATION.MISMATCH_MESSAGE,
     path: ['passwordConfirmation'],
   });
 
 export type SignupFormType = z.infer<typeof signupFormSchema>;
 
 export const loginFormSchema = z.object({
-  email: z.string().min(1, '이메일은 필수 입력입니다.').email('이메일 형식으로 작성해 주세요.'),
-  password: z.string().min(1, '비밀번호는 필수 입력입니다.'),
+  email: z
+    .string()
+    .min(1, AUTH_VALIDATION.EMAIL.REQUIRED_MESSAGE)
+    .email(AUTH_VALIDATION.EMAIL.INVALID_MESSAGE),
+
+  password: z.string().min(1, AUTH_VALIDATION.PASSWORD.REQUIRED_MESSAGE),
 });
 
 export type LoginFormType = z.infer<typeof loginFormSchema>;

--- a/src/apis/comment/comment.type.ts
+++ b/src/apis/comment/comment.type.ts
@@ -2,6 +2,16 @@ import { User } from 'next-auth';
 import { z } from 'zod';
 import { Epigram } from '../epigram/epigram.type';
 
+const MAX_LENGTH = 100;
+
+export const COMMENT_VALIDATION = {
+  CONTENT: {
+    REQUIRED_MESSAGE: '댓글을 입력해주세요',
+    MAX_LENGTH,
+    MAX_MESSAGE: `댓글은 최대 ${MAX_LENGTH}자까지 가능합니다.`,
+  },
+};
+
 export type Comment = {
   id: number;
   epigramId: Epigram['id'];
@@ -18,8 +28,10 @@ export const createCommentFormSchema = z.object({
   content: z
     .string()
     .trim()
-    .min(1, { message: '댓글을 입력해주세요' })
-    .max(100, { message: '100자 이내로 작성해주세요' }),
+    .min(1, { message: COMMENT_VALIDATION.CONTENT.REQUIRED_MESSAGE })
+    .max(COMMENT_VALIDATION.CONTENT.MAX_LENGTH, {
+      message: COMMENT_VALIDATION.CONTENT.MAX_MESSAGE,
+    }),
 });
 
 export type CreateCommentFormType = z.infer<typeof createCommentFormSchema>;

--- a/src/apis/epigram/epigram.type.ts
+++ b/src/apis/epigram/epigram.type.ts
@@ -1,6 +1,49 @@
 import { z } from 'zod';
 import { User } from '../user/user.type';
 
+const EPIGRAM_CONTENT_MAX_LENGTH = 500;
+const EPIGRAM_TAG_MAX_LENGTH = 10;
+const EPIGRAM_TAG_MAX_COUNT = 3;
+const EPIGRAM_AUTHOR_MAX_LENGTH = 30;
+const EPIGRAM_REFERENCE_TITLE_MAX_LENGTH = 100;
+
+export const EPIGRAM_VALIDATION = {
+  CONTENT: {
+    REQUIRED_MESSAGE: '내용을 작성해주세요.',
+    MAX_LENGTH: EPIGRAM_CONTENT_MAX_LENGTH,
+    MAX_MESSAGE: `내용은 최대 ${EPIGRAM_CONTENT_MAX_LENGTH}자까지 작성할 수 있어요.`,
+  },
+  TAG: {
+    REQUIRED_MESSAGE: '태그를 작성해주세요.',
+    MAX_LENGTH: EPIGRAM_TAG_MAX_LENGTH,
+    MAX_COUNT: EPIGRAM_TAG_MAX_COUNT,
+    MAX_MESSAGE: `태그는 최대 ${EPIGRAM_TAG_MAX_LENGTH}자까지 입력할 수 있어요.`,
+    COUNT_MESSAGE: `태그는 최대 ${EPIGRAM_TAG_MAX_COUNT}개까지만 등록할 수 있어요.`,
+    DUPLICATE_MESSAGE: '중복된 태그는 사용할 수 없어요.',
+  },
+  AUTHOR: {
+    REQUIRED_MESSAGE: '저자를 입력해주세요.',
+    SELECT_REQUIRED: '저자를 선택해주세요.',
+    MAX_LENGTH: EPIGRAM_AUTHOR_MAX_LENGTH,
+    MAX_MESSAGE: `저자는 최대 ${EPIGRAM_AUTHOR_MAX_LENGTH}자까지 작성할 수 있어요.`,
+  },
+  REFERENCE: {
+    URL_MESSAGE: '유효한 URL 형식으로 입력해주세요.',
+    TITLE_MAX_LENGTH: EPIGRAM_REFERENCE_TITLE_MAX_LENGTH,
+    TITLE_MAX_MESSAGE: `참고 제목은 최대 ${EPIGRAM_REFERENCE_TITLE_MAX_LENGTH}자까지 작성할 수 있어요.`,
+  },
+};
+
+const COMMENT_CONTENT_MAX_LENGTH = 100;
+
+export const COMMENT_VALIDATION = {
+  CONTENT: {
+    REQUIRED_MESSAGE: '댓글을 입력해주세요.',
+    MAX_LENGTH: COMMENT_CONTENT_MAX_LENGTH,
+    MAX_MESSAGE: `댓글은 최대 ${COMMENT_CONTENT_MAX_LENGTH}자까지 작성할 수 있어요.`,
+  },
+};
+
 export type Tag = {
   id: number;
   name: string;
@@ -22,34 +65,41 @@ export type EpigramDetail = Epigram & {
 };
 
 export const AUTHOR_RADIO = ['직접 입력', '본인', '알 수 없음'] as const;
+
 export const baseEpigramSchema = z.object({
   content: z
     .string()
     .trim()
-    .nonempty({ message: '내용을 작성해주세요.' })
-    .max(500, { message: '500자 이하로 작성해주세요.' }),
+    .nonempty({ message: EPIGRAM_VALIDATION.CONTENT.REQUIRED_MESSAGE })
+    .max(EPIGRAM_VALIDATION.CONTENT.MAX_LENGTH, {
+      message: EPIGRAM_VALIDATION.CONTENT.MAX_MESSAGE,
+    }),
+
   tags: z
     .array(
       z
         .string()
         .trim()
-        .nonempty({ message: '태그를 작성해주세요.' })
-        .max(10, { message: '10자 이하로 작성해주세요.' }),
+        .nonempty({ message: EPIGRAM_VALIDATION.TAG.REQUIRED_MESSAGE })
+        .max(EPIGRAM_VALIDATION.TAG.MAX_LENGTH, { message: EPIGRAM_VALIDATION.TAG.MAX_MESSAGE }),
     )
-    .max(3, { message: '최대 3개까지만 등록가능해요.' })
-    .refine(
-      (tags) => {
-        const set = new Set(tags);
-        return set.size === tags.length;
-      },
-      { message: '중복된 태그는 사용할 수 없어요.' },
-    ),
+    .max(EPIGRAM_VALIDATION.TAG.MAX_COUNT, { message: EPIGRAM_VALIDATION.TAG.COUNT_MESSAGE })
+    .refine((tags) => new Set(tags).size === tags.length, {
+      message: EPIGRAM_VALIDATION.TAG.DUPLICATE_MESSAGE,
+    }),
+
   selectedAuthor: z
     .enum(AUTHOR_RADIO, {
-      required_error: '저자를 선택해주세요.',
+      required_error: EPIGRAM_VALIDATION.AUTHOR.SELECT_REQUIRED,
     })
     .optional(),
-  author: z.string().trim().max(30, { message: '30자 이내로 입력해주세요.' }).optional().nullable(),
+
+  author: z
+    .string()
+    .trim()
+    .max(EPIGRAM_VALIDATION.AUTHOR.MAX_LENGTH, { message: EPIGRAM_VALIDATION.AUTHOR.MAX_MESSAGE })
+    .optional()
+    .nullable(),
 
   referenceUrl: z
     .string()
@@ -58,12 +108,15 @@ export const baseEpigramSchema = z.object({
     .nullable()
     .optional()
     .refine((val) => !val || /^https?:\/\//.test(val), {
-      message: '유효한 URL을 입력해주세요.',
+      message: EPIGRAM_VALIDATION.REFERENCE.URL_MESSAGE,
     }),
+
   referenceTitle: z
     .string()
     .trim()
-    .max(100, { message: '100자 이하로 입력해주세요.' })
+    .max(EPIGRAM_VALIDATION.REFERENCE.TITLE_MAX_LENGTH, {
+      message: EPIGRAM_VALIDATION.REFERENCE.TITLE_MAX_MESSAGE,
+    })
     .optional()
     .nullable(),
 });
@@ -73,13 +126,17 @@ export const createEpigramFormSchema = baseEpigramSchema.superRefine((data, ctx)
     ctx.addIssue({
       path: ['author'],
       code: z.ZodIssueCode.custom,
-      message: '저자를 작성해주세요.',
+      message: EPIGRAM_VALIDATION.AUTHOR.REQUIRED_MESSAGE,
     });
   }
 });
 
 export const commentSchema = z.object({
-  content: z.string().trim().min(1, '댓글을 입력해주세요').max(100, '100자 이내로 작성해주세요'),
+  content: z
+    .string()
+    .trim()
+    .min(1, COMMENT_VALIDATION.CONTENT.REQUIRED_MESSAGE)
+    .max(COMMENT_VALIDATION.CONTENT.MAX_LENGTH, COMMENT_VALIDATION.CONTENT.MAX_MESSAGE),
   isPrivate: z.boolean(),
 });
 

--- a/src/apis/user/user.type.ts
+++ b/src/apis/user/user.type.ts
@@ -9,14 +9,28 @@ export type User = {
   id: number;
 };
 
+const NICKNAME_MAX_LENGTH = 20;
 const ACCEPT_FILE_TYPE = ['image/jpeg', 'image/jpg', 'image/png'];
 const FILE_LIMIT_MB = 2;
+
+export const USER_VALIDATION = {
+  NICKNAME: {
+    REQUIRED_MESSAGE: '닉네임은 필수 입력입니다.',
+    MAX_LENGTH: NICKNAME_MAX_LENGTH,
+    MAX_MESSAGE: `닉네임은 최대 ${NICKNAME_MAX_LENGTH}자까지 가능합니다.`,
+  },
+  IMAGE: {
+    INVALID_TYPE_MESSAGE: '지원되지 않는 이미지 파일입니다',
+    FILE_LIMIT_MB,
+    MAX_SIZE_MESSAGE: `${FILE_LIMIT_MB}MB 이하로 올려주세요`,
+  },
+};
 
 export const updateUserFormSchema = z.object({
   nickname: z
     .string()
-    .min(1, '닉네임은 필수 입력입니다.')
-    .max(20, '닉네임은 최대 20자까지 가능합니다.'),
+    .min(1, USER_VALIDATION.NICKNAME.REQUIRED_MESSAGE)
+    .max(NICKNAME_MAX_LENGTH, USER_VALIDATION.NICKNAME.MAX_MESSAGE),
 
   image: z
     .union([
@@ -24,10 +38,10 @@ export const updateUserFormSchema = z.object({
       z
         .instanceof(File)
         .refine((file) => ACCEPT_FILE_TYPE.includes(file.type), {
-          message: '지원되지 않는 이미지 파일입니다',
+          message: USER_VALIDATION.IMAGE.INVALID_TYPE_MESSAGE,
         })
         .refine((file) => file.size < FILE_LIMIT_MB * 1024 * 1024, {
-          message: `${FILE_LIMIT_MB}MB 이하로 올려주세요`,
+          message: USER_VALIDATION.IMAGE.MAX_SIZE_MESSAGE,
         }),
     ])
     .optional()

--- a/src/components/Button.test.tsx
+++ b/src/components/Button.test.tsx
@@ -1,36 +1,38 @@
 import { render, screen } from '@testing-library/react';
 import Button from './Button';
 
+const TEST_BUTTON_TEXT = '클릭하기';
+
 describe('Button 컴포넌트', () => {
   it('기본 variant와 size로 렌더링된다', () => {
-    render(<Button>클릭하기</Button>);
-    const buttonElement = screen.getByRole('button', { name: /클릭하기/i });
+    render(<Button>{TEST_BUTTON_TEXT}</Button>);
+    const buttonElement = screen.getByRole('button', { name: new RegExp(TEST_BUTTON_TEXT, 'i') });
     expect(buttonElement).toHaveClass('bg-black-500');
     expect(buttonElement).toHaveClass('h-[44px]');
   });
 
   it('outlined variant로 렌더링된다', () => {
-    render(<Button variant='outlined'>클릭하기</Button>);
-    const buttonElement = screen.getByRole('button', { name: /클릭하기/i });
+    render(<Button variant='outlined'>{TEST_BUTTON_TEXT}</Button>);
+    const buttonElement = screen.getByRole('button', { name: new RegExp(TEST_BUTTON_TEXT, 'i') });
     expect(buttonElement).toHaveClass('bg-transparent');
     expect(buttonElement).toHaveClass('border');
   });
 
   it('size prop이 xs로 전달되면 xs 사이즈 클래스가 적용된다', () => {
-    render(<Button size='xs'>클릭하기</Button>);
-    const buttonElement = screen.getByRole('button', { name: /클릭하기/i });
+    render(<Button size='xs'>{TEST_BUTTON_TEXT}</Button>);
+    const buttonElement = screen.getByRole('button', { name: new RegExp(TEST_BUTTON_TEXT, 'i') });
     expect(buttonElement).toHaveClass('h-[32px]');
   });
 
   it('추가 className prop이 적용된다', () => {
-    render(<Button className='custom-class'>클릭하기</Button>);
-    const buttonElement = screen.getByRole('button', { name: /클릭하기/i });
+    render(<Button className='custom-class'>{TEST_BUTTON_TEXT}</Button>);
+    const buttonElement = screen.getByRole('button', { name: new RegExp(TEST_BUTTON_TEXT, 'i') });
     expect(buttonElement).toHaveClass('custom-class');
   });
 
   it('disabled 상태일 때 disabled 속성이 적용된다', () => {
-    render(<Button disabled>클릭하기</Button>);
-    const buttonElement = screen.getByRole('button', { name: /클릭하기/i });
+    render(<Button disabled>{TEST_BUTTON_TEXT}</Button>);
+    const buttonElement = screen.getByRole('button', { name: new RegExp(TEST_BUTTON_TEXT, 'i') });
     expect(buttonElement).toBeDisabled();
   });
 });

--- a/src/components/Chip.test.tsx
+++ b/src/components/Chip.test.tsx
@@ -1,29 +1,31 @@
 import { render, screen, fireEvent } from '@testing-library/react';
 import Chip from './Chip';
 
+const TEST_LABEL = '테스트 칩';
+
 describe('Chip 컴포넌트', () => {
   it('라벨이 정상적으로 렌더링된다', () => {
-    render(<Chip label='테스트 칩' />);
-    const labelElement = screen.getByText('테스트 칩');
+    render(<Chip label={TEST_LABEL} />);
+    const labelElement = screen.getByText(TEST_LABEL);
     expect(labelElement).toBeInTheDocument();
   });
 
   it('onRemove prop이 없으면 삭제 아이콘이 렌더링되지 않는다', () => {
-    render(<Chip label='테스트 칩' />);
+    render(<Chip label={TEST_LABEL} />);
     const svgElement = document.querySelector('svg');
     expect(svgElement).toBeNull();
   });
 
   it('onRemove prop이 있으면 삭제 아이콘이 렌더링된다', () => {
     const onRemoveMock = jest.fn();
-    render(<Chip label='테스트 칩' onRemove={onRemoveMock} />);
+    render(<Chip label={TEST_LABEL} onRemove={onRemoveMock} />);
     const svgElement = document.querySelector('svg');
     expect(svgElement).toBeInTheDocument();
   });
 
   it('삭제 아이콘 클릭 시 onRemove가 호출된다', () => {
     const onRemoveMock = jest.fn();
-    const { container } = render(<Chip label='테스트 칩' onRemove={onRemoveMock} />);
+    const { container } = render(<Chip label={TEST_LABEL} onRemove={onRemoveMock} />);
     const svgElement = container.querySelector('svg');
     expect(svgElement).toBeInTheDocument();
     if (svgElement) {

--- a/src/components/EmojiButton.test.tsx
+++ b/src/components/EmojiButton.test.tsx
@@ -1,6 +1,8 @@
 import { render, screen, fireEvent } from '@testing-library/react';
-import { EMOTION_LABEL } from '@/types/common'; // 적절한 경로로 수정
-import EmojiButton from './EmojiButton'; // 경로에 맞게 수정
+import { EMOTION_LABEL } from '@/types/common';
+import EmojiButton from './EmojiButton';
+
+const TEST_EMOJI_NAME = 'HAPPY';
 
 jest.mock('./Emoji', () => ({
   __esModule: true,
@@ -9,13 +11,13 @@ jest.mock('./Emoji', () => ({
 
 describe('EmojiButton Component', () => {
   test('버튼이 제대로 렌더링되는지 확인', () => {
-    render(<EmojiButton name='HAPPY' />);
+    render(<EmojiButton name={TEST_EMOJI_NAME} />);
 
-    expect(screen.getByText('HAPPY')).toBeInTheDocument();
+    expect(screen.getByText(TEST_EMOJI_NAME)).toBeInTheDocument();
   });
 
   test('selected가 true일 때 버튼의 스타일 변경 확인', () => {
-    render(<EmojiButton name='HAPPY' selected />);
+    render(<EmojiButton name={TEST_EMOJI_NAME} selected />);
 
     const button = screen.getByRole('button');
     expect(button).toHaveClass('bg-white');
@@ -23,7 +25,7 @@ describe('EmojiButton Component', () => {
   });
 
   test('selected가 false일 때 버튼의 스타일은 기본값 확인', () => {
-    render(<EmojiButton name='HAPPY' selected={false} />);
+    render(<EmojiButton name={TEST_EMOJI_NAME} selected={false} />);
 
     const button = screen.getByRole('button');
     expect(button).not.toHaveClass('bg-white');
@@ -31,20 +33,20 @@ describe('EmojiButton Component', () => {
   });
 
   test('withLabel의 기본값 확인(true일 때 라벨이 표시됨)', () => {
-    render(<EmojiButton name='HAPPY' withLabel />);
+    render(<EmojiButton name={TEST_EMOJI_NAME} withLabel />);
 
     expect(screen.getByText(EMOTION_LABEL.HAPPY)).toBeInTheDocument();
   });
 
   test('withLabel이 false일 때 라벨이 표시되지 않음', () => {
-    render(<EmojiButton name='HAPPY' withLabel={false} />);
+    render(<EmojiButton name={TEST_EMOJI_NAME} withLabel={false} />);
 
     expect(screen.queryByText(EMOTION_LABEL.HAPPY)).toBeNull();
   });
 
   test('클릭 이벤트가 제대로 호출되는지 확인', () => {
     const handleClick = jest.fn();
-    render(<EmojiButton name='HAPPY' onClick={handleClick} />);
+    render(<EmojiButton name={TEST_EMOJI_NAME} onClick={handleClick} />);
 
     const button = screen.getByRole('button');
     fireEvent.click(button);


### PR DESCRIPTION
## ❓이슈

- close #273 

## :memo: Description

### 작업 개요

유효성 검사 메시지와 매직 넘버를 상수화하여 코드의 가독성, 유지보수성, 재사용성을 향상시켰습니다.

### 작업 상세

- 유효성 검사 관련 하드코딩된 문자열을 각 컴포넌트 내 상수(객체 스타일)로 분리
- 매직 넘버들을 각 컴포넌트 내 상수로 분리
- 기존 코드의 기능은 그대로 유지하며, 코드 구조만 리팩토링

### 리팩토링 이유 및 기대 효과

- **가독성 향상** : 상수 이름을 통해 해당 값의 의미를 명확히 파악할 수 있으며, 하드코딩된 값들로 인한 혼란 방지
- **유지보수 용이** : 메시지나 숫자 값 변경 시에 한 곳만 수정하면 되어 수정 비용이 낮아짐
- **재사용성 증가** : 동일한 메시지나 값을 여러 곳에서 사용할 경우 일관되게 관리 가능
- **다국어 처리**에도 유리한 구조로, 향후 확장성을 고려한 사전 정비

## :cyclone: PR Type

어떤 변경 사항이 있나요?

<!-- 해당 사항에 체크해 주세요. -->

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항 (오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

### PR

<!-- 작성중인 PR인 경우, Draft 모드로 생성해주세요. -->

- [x] Branch Convention 확인
  > `feat/*` 기능 구현, `fix/*` 버그 수정, `refactor/*` 개선
- [x] Base Branch 확인
- [x] 적절한 Label 지정
- [x] Assignee 및 Reviewer 지정
