### PR TITLE
Refactor/279/오늘의감정로딩UI추가

### DIFF
--- a/src/apis/emotion/emotion.queries.ts
+++ b/src/apis/emotion/emotion.queries.ts
@@ -21,9 +21,9 @@ export const useCreateEmotionLog = (userId: number | null) => {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: (data: { emotion: Emotion }) => createEmotionLogToday(data),
-    onSuccess: () => {
+    onSuccess: async () => {
       if (userId !== null) {
-        queryClient.invalidateQueries({ queryKey: ['emotion'] });
+        await queryClient.invalidateQueries({ queryKey: ['emotion'] });
       }
     },
   });

--- a/src/app/(after-login)/epigrams/_components/TodayEmotion.tsx
+++ b/src/app/(after-login)/epigrams/_components/TodayEmotion.tsx
@@ -15,9 +15,16 @@ export default function TodayEmotion() {
   const showTodayMood = userId && !isLoading && !emotion;
 
   const handleEmotionClick = (emotion: Emotion) => {
-    if (isPending) return;
-
-    createEmotion({ emotion });
+    if (isPending) return Promise.resolve();
+    return new Promise<void>((resolve, reject) => {
+      createEmotion(
+        { emotion },
+        {
+          onSuccess: () => resolve(),
+          onError: () => reject(),
+        },
+      );
+    });
   };
 
   return (

--- a/src/app/(after-login)/mypage/_components/MyEmotions.tsx
+++ b/src/app/(after-login)/mypage/_components/MyEmotions.tsx
@@ -19,9 +19,16 @@ export default function MyEmotions() {
   const { data: moodData = {}, currentMonth, setCurrentMonth } = useEmotionLogsMonthly(userId);
 
   const handleEmotionClick = (emotion: Emotion) => {
-    if (isPending) return;
-
-    createEmotion({ emotion });
+    if (isPending) return Promise.resolve();
+    return new Promise<void>((resolve, reject) => {
+      createEmotion(
+        { emotion },
+        {
+          onSuccess: () => resolve(),
+          onError: () => reject(),
+        },
+      );
+    });
   };
 
   return (

--- a/src/components/TodayMood.tsx
+++ b/src/components/TodayMood.tsx
@@ -1,10 +1,12 @@
 'use client';
 
+import { useState } from 'react';
 import { format } from 'date-fns';
 import { EmotionLog } from '@/apis/emotion/emotion.type';
 import { EMOTION, Emotion } from '@/types/common';
 import { cn } from '@/utils/helper';
 import EmojiButton from './EmojiButton';
+import Spinner from './Spinner';
 
 interface TodayMoodProps {
   label?: string;
@@ -12,7 +14,7 @@ interface TodayMoodProps {
   labelClassName?: string;
   showDate?: boolean;
   emotion?: EmotionLog | null;
-  onEmotionClick: (emotion: Emotion) => void;
+  onEmotionClick: (emotion: Emotion) => Promise<void>;
 }
 
 export default function TodayMood({
@@ -23,8 +25,19 @@ export default function TodayMood({
   emotion,
   onEmotionClick,
 }: TodayMoodProps) {
+  const [isLoading, setIsLoading] = useState(false);
+
   const selectedEmotion = emotion?.emotion || null;
   const today = format(new Date(), 'yyyy.MM.dd');
+
+  const handleEmotionClick = async (emotion: Emotion) => {
+    setIsLoading(true);
+    try {
+      await onEmotionClick(emotion);
+    } finally {
+      setIsLoading(false);
+    }
+  };
 
   return (
     <>
@@ -34,20 +47,31 @@ export default function TodayMood({
         </label>
         {showDate && <span className='text-lg text-blue-400 lg:text-xl'>{today}</span>}
       </div>
-      <div
-        className={cn(
-          'mt-[24px] flex h-[84px] w-full justify-center gap-4 md:h-[96px] lg:mt-[48px] lg:h-[136px] lg:gap-6',
-          containerClassName,
+      <div className='relative'>
+        <div
+          className={cn(
+            'mt-[24px] flex h-[84px] w-full justify-center gap-4 md:h-[96px] lg:mt-[48px] lg:h-[136px] lg:gap-6',
+            containerClassName,
+          )}
+        >
+          {Object.values(EMOTION).map((emotion) => (
+            <EmojiButton
+              key={emotion}
+              name={emotion}
+              onClick={() => handleEmotionClick(emotion)}
+              selected={selectedEmotion === emotion}
+            />
+          ))}
+        </div>
+
+        {isLoading && (
+          <div className='bg-bg/60 absolute inset-0 z-10 flex items-center justify-center rounded-[12px] backdrop-blur-sm'>
+            <div className='flex flex-col items-center justify-center gap-4 p-4 text-center text-blue-400'>
+              <Spinner />
+              감정을 저장하고 있습니다.
+            </div>
+          </div>
         )}
-      >
-        {Object.values(EMOTION).map((emotion) => (
-          <EmojiButton
-            key={emotion}
-            name={emotion}
-            onClick={() => onEmotionClick(emotion)}
-            selected={selectedEmotion === emotion}
-          />
-        ))}
       </div>
     </>
   );


### PR DESCRIPTION
## ❓이슈

- close #279 

## :memo: Description

**작업 내용**
- 오늘의 감정(TodayMood) 컴포넌트 로딩 UI 추가
  - 다중 클릭 방지겸 오버레이 형식으로 로딩 UI를 구성했습니다.
  - 감정 선택이 다 끝나지 않았는데 로딩 UI가 조기 종료되어 `useCreateEmotionLog`에 await을 추가해줬습니다.

https://github.com/user-attachments/assets/bc911749-229b-4a03-b33b-068cd338e6e5


## :cyclone: PR Type

어떤 변경 사항이 있나요?

<!-- 해당 사항에 체크해 주세요. -->

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항 (오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

### PR

<!-- 작성중인 PR인 경우, Draft 모드로 생성해주세요. -->

- [x] Branch Convention 확인
  > `feat/*` 기능 구현, `fix/*` 버그 수정, `refactor/*` 개선
- [x] Base Branch 확인
- [x] 적절한 Label 지정
- [x] Assignee 및 Reviewer 지정
