### PR TITLE
Refactor/282/에피그램작성 코드수정

### DIFF
--- a/src/apis/epigram/epigram.queries.ts
+++ b/src/apis/epigram/epigram.queries.ts
@@ -15,8 +15,10 @@ import {
   disLikeEpigram,
   getTodayEpigram,
   getEpigramComments,
+  createEpigram,
+  updateEpigram,
 } from './epigram.service';
-import { Epigram, EpigramDetail } from './epigram.type';
+import { CreateEpigramFormType, Epigram, EpigramDetail } from './epigram.type';
 
 export const useEpigramSearchInfiniteQuery = (params: Omit<SearchableQueryParams, 'cursor'>) => {
   return useInfiniteQuery({
@@ -144,5 +146,27 @@ export const useFeedCommentsInFiniteQuery = (
       getEpigramComments(epigramId, { ...params, cursor: pageParam }),
     initialPageParam: undefined,
     getNextPageParam: (lastPage) => lastPage.nextCursor || undefined,
+  });
+};
+
+export const useCreateEpigram = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (data: CreateEpigramFormType) => createEpigram(data),
+    onSuccess: (result) => {
+      queryClient.invalidateQueries({ queryKey: ['epigrams', result.id] });
+    },
+  });
+};
+
+export const useUpdateEpigram = (epigramId: number) => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (data: CreateEpigramFormType) => updateEpigram(epigramId, data),
+    onSuccess: (result) => {
+      queryClient.setQueryData(['epigrams', epigramId], result);
+    },
   });
 };

--- a/src/app/(after-login)/epigrams/[id]/edit/page.tsx
+++ b/src/app/(after-login)/epigrams/[id]/edit/page.tsx
@@ -1,12 +1,10 @@
 'use client';
 
 import { use } from 'react';
-import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useSession } from 'next-auth/react';
 import { toast } from 'react-toastify';
 import { useRouter } from 'next/navigation';
-import { useEpigram } from '@/apis/epigram/epigram.queries';
-import { updateEpigram } from '@/apis/epigram/epigram.service';
+import { useEpigram, useUpdateEpigram } from '@/apis/epigram/epigram.queries';
 import { CreateEpigramFormType } from '@/apis/epigram/epigram.type';
 import ErrorPage from '@/app/error';
 import Inner from '@/components/Inner';
@@ -23,7 +21,6 @@ export default function EditEpigramPage({ params }: EditEpigramPageProps) {
   const { id } = use(params);
   const { data: session } = useSession();
   const sessionUserId = session?.user?.id;
-  const queryClient = useQueryClient();
   const epigramId = Number(id);
 
   const { details } = useEpigram(epigramId);
@@ -31,12 +28,7 @@ export default function EditEpigramPage({ params }: EditEpigramPageProps) {
   const isLoading = details.isLoading;
   const isError = details.isError;
 
-  const { mutateAsync, isPending } = useMutation({
-    mutationFn: (data: CreateEpigramFormType) => updateEpigram(epigramId, data),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['epigrams'] });
-    },
-  });
+  const { mutateAsync, isPending } = useUpdateEpigram(epigramId);
 
   const handleUpdate = async (formData: CreateEpigramFormType) => {
     try {

--- a/src/app/(after-login)/epigrams/create/page.tsx
+++ b/src/app/(after-login)/epigrams/create/page.tsx
@@ -1,9 +1,8 @@
 'use client';
 
-import { useMutation } from '@tanstack/react-query';
 import { toast } from 'react-toastify';
 import { useRouter } from 'next/navigation';
-import { createEpigram } from '@/apis/epigram/epigram.service';
+import { useCreateEpigram } from '@/apis/epigram/epigram.queries';
 import { CreateEpigramFormType } from '@/apis/epigram/epigram.type';
 import Inner from '@/components/Inner';
 import { Section } from '@/components/Section';
@@ -11,9 +10,8 @@ import EpigramForm from '../_components/EpigramForm';
 
 export default function Page() {
   const router = useRouter();
-  const { mutateAsync, isPending } = useMutation({
-    mutationFn: createEpigram,
-  });
+  const { mutateAsync, isPending } = useCreateEpigram();
+
   return (
     <Inner className='p-6 lg:py-8'>
       <Section>에피그램 만들기</Section>

--- a/src/app/(after-login)/epigrams/create/page.tsx
+++ b/src/app/(after-login)/epigrams/create/page.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { useMutation } from '@tanstack/react-query';
-import { useForm } from 'react-hook-form';
 import { toast } from 'react-toastify';
 import { useRouter } from 'next/navigation';
 import { createEpigram } from '@/apis/epigram/epigram.service';
@@ -15,9 +14,6 @@ export default function Page() {
   const { mutateAsync, isPending } = useMutation({
     mutationFn: createEpigram,
   });
-  const methods = useForm();
-  const { reset } = methods;
-
   return (
     <Inner className='p-6 lg:py-8'>
       <Section>에피그램 만들기</Section>
@@ -28,7 +24,6 @@ export default function Page() {
           try {
             const result = await mutateAsync(data);
             toast.success('에피그램이 작성되었습니다.');
-            reset();
             router.push(`/epigrams/${result.id}`);
           } catch (error) {
             console.error('에피그램 작성 실패:', error);


### PR DESCRIPTION
## ❓이슈

- close #282


### 변경 내용

- 에피그램 작성용 `useCreateEpigram` 훅 생성 및 적용
- 에피그램 수정용 `useUpdateEpigram` 훅 생성 및 적용
- mutation 관련 로직 분리
- 중복된 `reset()` 호출 제거 -> 실제 폼 리셋은 `EpigramForm` 내부에서만 수행

### 변경 이유

- mutation 관련 로직을 각 페이지에서 분리하여 가독성 향상
- 재사용 가능한 커스텀 훅 구조로 정리
- 불필요한 중복 리셋 호출 제거

## :memo: Description

<!-- 어떤 내용의 PR인지 작성해 주세요. (ex. 메인 페이지 레이아웃 작업) -->
<!-- ⚠️ PR에는 해당 PR의 제목에 해당하는 내용만 들어가 있어야 합니다!  -->

## :cyclone: PR Type

어떤 변경 사항이 있나요?

<!-- 해당 사항에 체크해 주세요. -->

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항 (오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [x] 파일 혹은 폴더 삭제

### PR

<!-- 작성중인 PR인 경우, Draft 모드로 생성해주세요. -->

- [x] Branch Convention 확인
  > `feat/*` 기능 구현, `fix/*` 버그 수정, `refactor/*` 개선
- [x] Base Branch 확인
- [x] 적절한 Label 지정
- [x] Assignee 및 Reviewer 지정
